### PR TITLE
chore: remove v0.dev automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # O-Z/Gedney Clone
 
-*Automatically synced with your [v0.dev](https://v0.dev) deployments*
-
 [![Deployed on Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?style=for-the-badge&logo=vercel)](https://vercel.com/lazapas-projects/v0-o-z-gedney-clone)
-[![Built with v0](https://img.shields.io/badge/Built%20with-v0.dev-black?style=for-the-badge)](https://v0.dev/chat/projects/jfPEFRzTRqa)
 
 ## Overview
 
-This repository will stay in sync with your deployed chats on [v0.dev](https://v0.dev).
-Any changes you make to your deployed app will be automatically pushed to this repository from [v0.dev](https://v0.dev).
+This project was originally scaffolded with [v0.dev](https://v0.dev), but automated syncing has been disabled. The repository is now maintained manually and all updates originate from local development.
 
 ## Deployment
 
@@ -16,15 +12,9 @@ Your project is live at:
 
 **[https://vercel.com/lazapas-projects/v0-o-z-gedney-clone](https://vercel.com/lazapas-projects/v0-o-z-gedney-clone)**
 
-## Build your app
+## Development
 
-Continue building your app on:
-
-**[https://v0.dev/chat/projects/jfPEFRzTRqa](https://v0.dev/chat/projects/jfPEFRzTRqa)**
-
-## How It Works
-
-1. Create and modify your project using [v0.dev](https://v0.dev)
-2. Deploy your chats from the v0 interface
-3. Changes are automatically pushed to this repository
-4. Vercel deploys the latest version from this repository
+1. Clone this repository.
+2. Install dependencies with `pnpm install`.
+3. Run the development server with `pnpm dev`.
+4. Commit and push changes from your local environment.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,6 @@ export const metadata: Metadata = {
     description: "ผู้จำหน่าย O-Z/Gedney Conduit Body คุณภาพสูง มาตรฐาน UL และ NEMA",
     images: ["/og-image.jpg"],
   },
-    generator: 'v0.dev'
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- remove v0.dev generator tag
- update README to reflect manual maintenance

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68935b62c1748325bf82083106e0da4d