### PR TITLE
Ensure Next.js builds fail on lint and type errors

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary
- fail builds if ESLint or TypeScript errors occur by disabling `ignoreDuringBuilds` and `ignoreBuildErrors`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: You're importing a component that needs "next/headers"… Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68938f63331c8325835fe0bed76699aa