### PR TITLE
Specify Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Your project is live at:
 
 ## Development
 
+This project requires **Node.js 18 or higher**.
+
 1. Clone this repository.
 2. Install dependencies with `pnpm install`.
 3. Run the development server with `pnpm dev`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lint": "next lint",
     "start": "next start"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@emotion/is-prop-valid": "1.3.1",
     "@neondatabase/serverless": "1.0.1",


### PR DESCRIPTION
## Summary
- declare Node >=18 support via package.json `engines`
- document Node.js 18+ requirement in README

## Testing
- `npm test` (fails: Missing script: "test")
- `pnpm lint` (fails: Next.js ESLint configuration prompt)

------
https://chatgpt.com/codex/tasks/task_e_689394e75394832597dcdcab97dd947d