### PR TITLE
feat: protect admin routes with middleware

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -50,8 +50,8 @@ export default function AdminLogin() {
       if (authError) {
         setError(authError.message)
       } else if (data.user) {
-        // If login is successful, update the Zustand store
-        login(credentials.remember)
+        // If login is successful, update the Zustand store with user info
+        login({ id: data.user.id, email: data.user.email })
         router.push("/admin")
       } else {
         setError("ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง") // Fallback for unexpected cases

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function middleware(req: NextRequest) {
+  const url = req.nextUrl.clone();
+
+  // Allow the login page to load without checks
+  if (url.pathname.startsWith('/admin/login')) {
+    return NextResponse.next();
+  }
+
+  const accessToken = req.cookies.get('sb-access-token')?.value;
+  if (!accessToken) {
+    url.pathname = '/admin/login';
+    return NextResponse.redirect(url);
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  const { data, error } = await supabase.auth.getUser(accessToken);
+  const user = data?.user;
+
+  if (error || !user || user.user_metadata?.role !== 'admin') {
+    url.pathname = '/admin/login';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+};


### PR DESCRIPTION
## Summary
- add Next.js middleware to guard `/admin` paths using Supabase sessions
- store authenticated user info on admin login

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68941a9eab748325a8e1fcbd01ea66ba