### PR TITLE
refactor: avoid server headers in browser builds

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,4 @@
 import { createClient } from '@supabase/supabase-js';
-import { cookies } from 'next/headers';
 
 // Client-side Supabase client (for public actions, RLS-enabled)
 // Should use NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -16,6 +15,7 @@ export const supabaseBrowser = createSupabaseBrowserClient;
 // Server-side Supabase client (for Server Components/Actions, RLS-enabled)
 // Should use SUPABASE_ANON_KEY (or NEXT_PUBLIC_SUPABASE_ANON_KEY if preferred for consistency)
 export function createSupabaseServerClient() {
+  const { cookies } = require('next/headers');
   const cookieStore = cookies();
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- avoid importing `next/headers` in the shared Supabase client to prevent client build failures

## Testing
- `pnpm build` *(fails: Attempted import error: 'updateOrder' is not exported from '@/actions/orders' ...)*
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*


------
https://chatgpt.com/codex/tasks/task_e_68946d9885d083258d72d0de80d721cc