### PR TITLE
test: add unit tests for actions

### DIFF
--- a/__tests__/orders.test.ts
+++ b/__tests__/orders.test.ts
@@ -1,0 +1,119 @@
+import { revalidatePath } from 'next/cache';
+import { createSupabaseAdminClient } from '@/lib/supabase';
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  createSupabaseAdminClient: jest.fn(),
+  createSupabaseServerClient: jest.fn(),
+}));
+
+import { createOrder, updateOrderStatus } from '../actions/orders';
+
+describe('orders actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('createOrder success', async () => {
+    const mockFrom = jest.fn();
+    const mockSupabase = { from: mockFrom } as any;
+    (createSupabaseAdminClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const insertOrder = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: { id: 'order1' }, error: null }),
+      }),
+    });
+
+    const insertItems = jest.fn().mockResolvedValue({ error: null });
+
+    const selectProduct = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: { stock_quantity: 10 }, error: null }),
+      }),
+    });
+
+    const updateProduct = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'orders') return { insert: insertOrder };
+      if (table === 'order_items') return { insert: insertItems };
+      if (table === 'products') return { select: selectProduct, update: updateProduct };
+      return {};
+    });
+
+    const cartItems = [
+      { id: 'prod1', quantity: 2, base_price: 5, name: 'Prod1', stock_quantity: 10 },
+    ];
+
+    const result = await createOrder('user1', 10, cartItems as any);
+
+    expect(result).toEqual({ success: true, orderId: 'order1' });
+    expect(revalidatePath).toHaveBeenCalledWith('/admin/orders');
+    expect(revalidatePath).toHaveBeenCalledWith('/order-history');
+    expect(revalidatePath).toHaveBeenCalledWith('/products/[slug]', 'page');
+  });
+
+  test('createOrder failure', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseAdminClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const insertOrder = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: null, error: { message: 'insert error' } }),
+      }),
+    });
+
+    mockSupabase.from.mockReturnValueOnce({ insert: insertOrder });
+
+    const result = await createOrder('user1', 10, []);
+
+    expect(result).toEqual({ success: false, error: 'insert error' });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  test('updateOrderStatus success', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseAdminClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const updateOrder = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { id: 'order1', status: 'shipped' }, error: null }),
+        }),
+      }),
+    });
+
+    mockSupabase.from.mockReturnValueOnce({ update: updateOrder });
+
+    const result = await updateOrderStatus('order1', 'shipped');
+
+    expect(result).toEqual({ success: true, order: { id: 'order1', status: 'shipped' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/admin/orders');
+    expect(revalidatePath).toHaveBeenCalledWith('/order-history');
+  });
+
+  test('updateOrderStatus failure', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseAdminClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const updateOrder = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: null, error: { message: 'update error' } }),
+        }),
+      }),
+    });
+
+    mockSupabase.from.mockReturnValueOnce({ update: updateOrder });
+
+    const result = await updateOrderStatus('order1', 'shipped');
+
+    expect(result).toEqual({ success: false, error: 'update error' });
+  });
+});

--- a/__tests__/products.test.ts
+++ b/__tests__/products.test.ts
@@ -1,0 +1,99 @@
+import { revalidatePath } from 'next/cache';
+import { createSupabaseAdminClient, createSupabaseServerClient } from '@/lib/supabase';
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  createSupabaseAdminClient: jest.fn(),
+  createSupabaseServerClient: jest.fn(),
+}));
+
+import { fetchProducts, addProduct } from '../actions/products';
+
+describe('products actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetchProducts success', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseServerClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const rangeMock = jest.fn().mockResolvedValue({ data: [{ id: 'p1' }], error: null });
+    const orderMock = jest.fn().mockReturnValue({ range: rangeMock });
+    const selectMock = jest.fn().mockReturnValue({ order: orderMock });
+    mockSupabase.from.mockReturnValueOnce({ select: selectMock });
+
+    const selectCountMock = jest.fn().mockResolvedValue({ count: 1, error: null });
+    mockSupabase.from.mockReturnValueOnce({ select: selectCountMock });
+
+    const result = await fetchProducts(1, 10);
+
+    expect(result).toEqual({ products: [{ id: 'p1' }], totalCount: 1, error: null });
+  });
+
+  test('fetchProducts failure', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseServerClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const rangeMock = jest.fn().mockResolvedValue({ data: null, error: { message: 'fetch error' } });
+    const orderMock = jest.fn().mockReturnValue({ range: rangeMock });
+    const selectMock = jest.fn().mockReturnValue({ order: orderMock });
+    mockSupabase.from.mockReturnValueOnce({ select: selectMock });
+
+    const result = await fetchProducts();
+
+    expect(result).toEqual({ products: [], totalCount: 0, error: 'fetch error' });
+  });
+
+  test('addProduct success', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseAdminClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const insertMock = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: { id: 'p1', name: 'Prod' }, error: null }),
+      }),
+    });
+
+    mockSupabase.from.mockReturnValueOnce({ insert: insertMock });
+
+    const productData = {
+      name: 'Prod',
+      slug: 'prod',
+      base_price: 10,
+      stock_quantity: 5,
+      description: '',
+      image_url: '',
+      category: '',
+      type: '',
+      material: '',
+      is_featured: false,
+    } as any;
+
+    const result = await addProduct(productData);
+
+    expect(result).toEqual({ success: true, product: { id: 'p1', name: 'Prod' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/admin/products');
+    expect(revalidatePath).toHaveBeenCalledWith('/products');
+  });
+
+  test('addProduct failure', async () => {
+    const mockSupabase = { from: jest.fn() } as any;
+    (createSupabaseAdminClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    const insertMock = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: null, error: { message: 'insert error' } }),
+      }),
+    });
+
+    mockSupabase.from.mockReturnValueOnce({ insert: insertMock });
+
+    const result = await addProduct({} as any);
+
+    expect(result).toEqual({ success: false, error: 'insert error' });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
 };


### PR DESCRIPTION
## Summary
- add moduleNameMapper for path aliases in jest
- test createOrder and updateOrderStatus actions with mocked Supabase
- test fetchProducts and addProduct actions with mocked Supabase

## Testing
- `npm test >/tmp/unit.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_6894be37c90c8325b349fb6ffb01ae68