### PR TITLE
Add Supabase env var validation

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,12 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('❌ Missing Supabase URL or Anon Key');
+}
+
 // Client-side Supabase client (for public actions, RLS-enabled)
 // Should use NEXT_PUBLIC_SUPABASE_ANON_KEY
 export function createSupabaseBrowserClient() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  return createClient(supabaseUrl, supabaseAnonKey);
 }
 
 // Exporting the browser client function with the requested name
@@ -18,8 +22,8 @@ export function createSupabaseServerClient() {
   const { cookies } = require('next/headers');
   const cookieStore = cookies();
   return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, // Using NEXT_PUBLIC for consistency with browser client
+    supabaseUrl,
+    supabaseAnonKey, // Using NEXT_PUBLIC for consistency with browser client
     {
       cookies: {
         get: (name: string) => cookieStore.get(name)?.value,
@@ -34,7 +38,7 @@ export function createSupabaseServerClient() {
 // Should use SUPABASE_SERVICE_ROLE_KEY
 export function createSupabaseAdminClient() {
   return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    supabaseUrl,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       auth: {


### PR DESCRIPTION
## Summary
- validate presence of Supabase URL and anon key before creating clients
- reuse validated values when constructing browser, server, and admin Supabase clients

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e7fddb608325b3b02a286355291b