### PR TITLE
feat: centralize mock data layer

### DIFF
--- a/__tests__/orders.test.ts
+++ b/__tests__/orders.test.ts
@@ -1,10 +1,10 @@
 import { fetchOrders, createOrder, updateOrderStatus } from '@/actions/orders'
-import { mockOrders } from '@/lib/mock/orders'
+import { mockDb } from '@/lib/mockDb'
 
 describe('orders actions', () => {
   test('fetchOrders returns mock data', async () => {
     const result = await fetchOrders(1,10)
-    expect(result).toEqual({ orders: mockOrders, totalCount: mockOrders.length, error: null })
+    expect(result).toEqual({ orders: mockDb.orders, totalCount: mockDb.orders.length, error: null })
   })
 
   test('createOrder returns success', async () => {

--- a/__tests__/products.test.ts
+++ b/__tests__/products.test.ts
@@ -1,10 +1,10 @@
 import { fetchProducts, addProduct } from '@/actions/products'
-import { mockProducts } from '@/lib/mock/products'
+import { mockDb } from '@/lib/mockDb'
 
 describe('products actions', () => {
   test('fetchProducts returns mock data', async () => {
     const result = await fetchProducts(1, 10)
-    expect(result).toEqual({ products: mockProducts, totalCount: mockProducts.length, error: null })
+    expect(result).toEqual({ products: mockDb.products, totalCount: mockDb.products.length, error: null })
   })
 
   test('addProduct returns success', async () => {

--- a/actions/analytics.ts
+++ b/actions/analytics.ts
@@ -1,8 +1,6 @@
 'use server'
 
-import { mockOrders } from '@/lib/mock/orders'
-import { mockUsers } from '@/lib/mock/users'
-import { mockProducts } from '@/lib/mock/products'
+import { mockDb } from '@/lib/mockDb'
 
 export interface SalesSummaryPoint {
   date: string
@@ -26,21 +24,21 @@ function isWithinRange(date: string, start: string, end: string) {
 }
 
 export async function getSalesSummaryRange(start: string, end: string) {
-  const summary = mockOrders
+  const summary = mockDb.orders
     .filter(o => isWithinRange(o.created_at, start, end))
     .map(o => ({ date: o.created_at.split('T')[0], total: o.total_amount }))
   return { summary, error: null }
 }
 
 export async function getUserGrowthTrendRange(start: string, end: string) {
-  const trend = mockUsers
+  const trend = mockDb.users
     .filter(u => isWithinRange(u.created_at, start, end))
     .map(u => ({ date: u.created_at.split('T')[0], count: 1 }))
   return { trend, error: null }
 }
 
 export async function getDailyOrderCountsRange(start: string, end: string) {
-  const counts = mockOrders
+  const counts = mockDb.orders
     .filter(o => isWithinRange(o.created_at, start, end))
     .map(o => ({ date: o.created_at.split('T')[0], count: 1 }))
   return { counts, error: null }
@@ -48,7 +46,7 @@ export async function getDailyOrderCountsRange(start: string, end: string) {
 
 export async function getTopProducts(start: string, end: string, limit: number) {
   const totals: Record<string, number> = {}
-  mockOrders
+  mockDb.orders
     .filter(o => isWithinRange(o.created_at, start, end))
     .forEach(o => {
       o.order_items?.forEach(item => {
@@ -57,7 +55,7 @@ export async function getTopProducts(start: string, end: string, limit: number) 
     })
   const products = Object.entries(totals)
     .map(([id, qty]) => {
-      const product = mockProducts.find(p => p.id === id)
+      const product = mockDb.products.find(p => p.id === id)
       return { id, name: product?.name || 'Unknown', totalSold: qty }
     })
     .sort((a, b) => b.totalSold - a.totalSold)

--- a/actions/leads.ts
+++ b/actions/leads.ts
@@ -1,29 +1,62 @@
 'use server'
 
-import { mockLeads, Lead } from '@/lib/mock/leads'
+import { mockDb } from '@/lib/mockDb'
+import { Lead } from '@/lib/mock/leads'
 
 export async function fetchLeads(): Promise<Lead[]> {
-  return mockLeads
+  return mockDb.leads
 }
 
 type ActionResult = { success: boolean; error?: string }
 
 export async function addLead(formData: FormData): Promise<ActionResult> {
+  const data = Object.fromEntries(formData.entries()) as Record<string, string>
+  const newLead: Lead = {
+    id: String(mockDb.leads.length + 1),
+    customerName: data.name || '',
+    company: data.company || '',
+    phone: data.phone || '',
+    email: data.email || '',
+    productInterest: data.productInterest || '',
+    size: data.size || '',
+    quantity: data.quantity || '',
+    status: data.status || 'ใหม่',
+    notes: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  mockDb.leads.push(newLead)
   return { success: true }
 }
 
 export async function deleteLead(id: string): Promise<ActionResult> {
-  return { success: true }
+  const idx = mockDb.leads.findIndex(l => l.id === id)
+  if (idx !== -1) {
+    mockDb.leads.splice(idx, 1)
+    return { success: true }
+  }
+  return { success: false, error: 'Lead not found' }
 }
 
 export async function fetchLeadCount(): Promise<number> {
-  return mockLeads.length
+  return mockDb.leads.length
 }
 
 export async function updateLeadStatus(id: string, status: string): Promise<ActionResult> {
-  return { success: true }
+  const lead = mockDb.leads.find(l => l.id === id)
+  if (lead) {
+    lead.status = status
+    return { success: true }
+  }
+  return { success: false, error: 'Lead not found' }
 }
 
 export async function addNoteToLead(id: string, note: string): Promise<ActionResult> {
-  return { success: true }
+  const lead = mockDb.leads.find(l => l.id === id)
+  if (lead) {
+    lead.notes = lead.notes || []
+    lead.notes.push(note)
+    return { success: true }
+  }
+  return { success: false, error: 'Lead not found' }
 }

--- a/actions/orders.ts
+++ b/actions/orders.ts
@@ -1,9 +1,9 @@
 'use server'
 
-import { mockOrders, MockOrder, MockOrderItem } from '@/lib/mock/orders'
+import { mockDb, ShippingInfo } from '@/lib/mockDb'
+import { MockOrder, MockOrderItem } from '@/lib/mock/orders'
 
-export interface OrderItem
-  extends Omit<MockOrderItem, 'price_at_purchase'> {
+export interface OrderItem extends Omit<MockOrderItem, 'price_at_purchase'> {
   price_at_purchase: number
   product_image_url?: string
   product_slug?: string
@@ -15,21 +15,21 @@ export interface Order extends Omit<MockOrder, 'order_items'> {
 
 export async function fetchOrders(page: number = 1, limit: number = 10) {
   const offset = (page - 1) * limit
-  const orders = mockOrders.slice(offset, offset + limit) as Order[]
-  return { orders, totalCount: mockOrders.length, error: null }
+  const orders = mockDb.orders.slice(offset, offset + limit) as Order[]
+  return { orders, totalCount: mockDb.orders.length, error: null }
 }
 
 export async function fetchOrderById(orderId: string) {
-  const order = (mockOrders.find((o) => o.id === orderId) as Order) || null
+  const order = (mockDb.orders.find(o => o.id === orderId) as Order) || null
   return { order, error: null }
 }
 
 export async function fetchOrderCount() {
-  return { count: mockOrders.length, error: null }
+  return { count: mockDb.orders.length, error: null }
 }
 
 export async function fetchRecentOrders(limit: number) {
-  return { orders: mockOrders.slice(0, limit) as Order[], error: null }
+  return { orders: mockDb.orders.slice(0, limit) as Order[], error: null }
 }
 
 export interface CartItem { id: string; quantity: number; base_price: number }
@@ -37,10 +37,10 @@ export interface CartItem { id: string; quantity: number; base_price: number }
 export async function createOrder(
   userId: string,
   totalAmount: number,
-  cartItems: CartItem[]
+  cartItems: CartItem[],
 ) {
-  const order: Order = {
-    id: 'new',
+  const newOrder: Order = {
+    id: String(mockDb.orders.length + 1),
     user_id: userId,
     total_amount: totalAmount,
     status: 'pending',
@@ -54,29 +54,47 @@ export async function createOrder(
       price_at_purchase: ci.base_price,
     })),
   }
-
-  return {
-    success: true,
-    orderId: order.id,
-    order,
-    error: null,
+  mockDb.orders.push(newOrder)
+  const ship: ShippingInfo = {
+    order_id: newOrder.id,
+    status: 'pending',
+    updated_at: new Date().toISOString(),
   }
+  mockDb.shipping.push(ship)
+  return { success: true, orderId: newOrder.id, order: newOrder, error: null }
 }
 
 type ActionResult = { success: boolean; error?: string }
 
 export async function updateOrder(id: string, data: Partial<Order>): Promise<ActionResult> {
-  return { success: true }
+  const order = mockDb.orders.find(o => o.id === id)
+  if (order) {
+    Object.assign(order, data)
+    return { success: true }
+  }
+  return { success: false, error: 'Order not found' }
 }
 
 export async function deleteOrder(id: string): Promise<ActionResult> {
-  return { success: true }
+  const idx = mockDb.orders.findIndex(o => o.id === id)
+  if (idx !== -1) {
+    mockDb.orders.splice(idx, 1)
+    return { success: true }
+  }
+  return { success: false, error: 'Order not found' }
 }
 
 export async function updateOrderStatus(id: string, status: string): Promise<ActionResult> {
-  return { success: true }
+  const order = mockDb.orders.find(o => o.id === id)
+  if (order) {
+    order.status = status
+    const ship = mockDb.shipping.find(s => s.order_id === id)
+    if (ship) ship.status = status
+    return { success: true }
+  }
+  return { success: false, error: 'Order not found' }
 }
 
 export async function fetchUserOrders(userId: string) {
-  return mockOrders.filter((o) => o.user_id === userId) as Order[]
+  return mockDb.orders.filter(o => o.user_id === userId) as Order[]
 }

--- a/actions/payments.ts
+++ b/actions/payments.ts
@@ -1,39 +1,24 @@
 'use server'
 
-import Stripe from 'stripe';
-import { updateOrderStatus } from './orders';
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2024-04-10' as Stripe.LatestApiVersion,
-});
+import { mockDb } from '@/lib/mockDb'
+import { updateOrderStatus } from './orders'
 
 export async function createPaymentIntent(amount: number, orderId: string) {
-  try {
-    const paymentIntent = await stripe.paymentIntents.create({
-      amount: Math.round(amount * 100),
-      currency: 'usd',
-      metadata: { order_id: orderId },
-    });
-    return { clientSecret: paymentIntent.client_secret, error: null };
-  } catch (error: any) {
-    console.error('Error creating payment intent:', error.message);
-    return { clientSecret: null, error: error.message };
-  }
+  const id = `pi_${mockDb.payments.length + 1}`
+  mockDb.payments.push({ id, order_id: orderId, amount, status: 'pending', created_at: new Date().toISOString() })
+  return { clientSecret: id, error: null }
 }
 
 export async function confirmPayment(paymentIntentId: string) {
-  try {
-    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
-    if (paymentIntent.status === 'succeeded') {
-      const orderId = paymentIntent.metadata.order_id;
-      if (orderId) {
-        await updateOrderStatus(orderId, 'processing');
-      }
-      return { success: true, orderId, error: null };
-    }
-    return { success: false, orderId: null, error: `Payment not succeeded. Status: ${paymentIntent.status}` };
-  } catch (error: any) {
-    console.error('Error confirming payment:', error.message);
-    return { success: false, orderId: null, error: error.message };
+  const payment = mockDb.payments.find(p => p.id === paymentIntentId)
+  if (!payment) {
+    return { success: false, orderId: null, error: 'Payment not found' }
   }
+  payment.status = 'succeeded'
+  const order = mockDb.orders.find(o => o.id === payment.order_id)
+  if (order) {
+    order.payment_status = 'paid'
+    await updateOrderStatus(order.id, 'processing')
+  }
+  return { success: true, orderId: payment.order_id, error: null }
 }

--- a/actions/products.ts
+++ b/actions/products.ts
@@ -1,38 +1,52 @@
 'use server'
 
-import { mockProducts } from '@/lib/mock/products'
+import { mockDb } from '@/lib/mockDb'
 import { Product } from '@/types/product'
 
 export async function fetchProducts(page: number = 1, limit: number = 10) {
   const offset = (page - 1) * limit
-  const products = mockProducts.slice(offset, offset + limit)
-  return { products, totalCount: mockProducts.length, error: null }
+  const products = mockDb.products.slice(offset, offset + limit)
+  return { products, totalCount: mockDb.products.length, error: null }
 }
 
 export async function fetchProductBySlug(slug: string) {
-  const product = mockProducts.find(p => p.slug === slug) || null
+  const product = mockDb.products.find(p => p.slug === slug) || null
   return { product, error: null }
 }
 
 export async function fetchProductCount() {
-  return { count: mockProducts.length, error: null }
+  return { count: mockDb.products.length, error: null }
 }
 
 export async function fetchRecentProducts(limit: number) {
-  return { products: mockProducts.slice(0, limit), error: null }
+  return { products: mockDb.products.slice(0, limit), error: null }
 }
 
 type ActionResult<T = {}> = { success: boolean; error?: string } & T
 
 export async function addProduct(productData: Omit<Product, 'id' | 'created_at' | 'updated_at'>): Promise<ActionResult<{ product: Product }>> {
-  return { success: true, product: { ...productData, id: 'new', created_at: '', updated_at: '' } as Product }
+  const newProduct: Product = {
+    ...productData,
+    id: String(mockDb.products.length + 1),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+  mockDb.products.push(newProduct)
+  return { success: true, product: newProduct }
 }
 
 export async function updateProduct(id: string, productData: Partial<Omit<Product, 'id' | 'created_at'>>): Promise<ActionResult<{ product: Product | null }>> {
-  const product = mockProducts.find(p => p.id === id) || null
+  const product = mockDb.products.find(p => p.id === id) || null
+  if (product) {
+    Object.assign(product, productData, { updated_at: new Date().toISOString() })
+  }
   return { success: true, product }
 }
 
 export async function deleteProduct(id: string): Promise<ActionResult> {
+  const idx = mockDb.products.findIndex(p => p.id === id)
+  if (idx !== -1) {
+    mockDb.products.splice(idx, 1)
+  }
   return { success: true }
 }

--- a/actions/users.ts
+++ b/actions/users.ts
@@ -1,35 +1,63 @@
 'use server'
 
-import { mockUsers, User } from '@/lib/mock/users'
+import { mockDb } from '@/lib/mockDb'
+import { User } from '@/lib/mock/users'
 
 export async function fetchUsers(page: number = 1, limit: number = 10): Promise<{ users: User[]; totalCount: number; error: null }> {
   const offset = (page - 1) * limit
-  const users = mockUsers.slice(offset, offset + limit)
-  return { users, totalCount: mockUsers.length, error: null }
+  const users = mockDb.users.slice(offset, offset + limit)
+  return { users, totalCount: mockDb.users.length, error: null }
 }
 
 export async function fetchUserCount() {
-  return { count: mockUsers.length, error: null }
+  return { count: mockDb.users.length, error: null }
 }
 
 export async function fetchRecentUsers(limit: number): Promise<{ users: User[]; error: null }> {
-  return { users: mockUsers.slice(0, limit), error: null }
+  return { users: mockDb.users.slice(0, limit), error: null }
 }
 
 type ActionResult<T = {}> = { success: boolean; error?: string } & T
 
-export async function updateUserRole(): Promise<ActionResult<{ user: User | null }>> {
-  return { success: true, user: null }
+export async function updateUserRole(id: string, role: string): Promise<ActionResult<{ user: User | null }>> {
+  const user = mockDb.users.find(u => u.id === id) || null
+  if (user) {
+    user.role = role
+    return { success: true, user }
+  }
+  return { success: false, user: null, error: 'User not found' }
 }
 
 export async function deleteUser(id: string): Promise<ActionResult> {
-  return { success: true }
+  const idx = mockDb.users.findIndex(u => u.id === id)
+  if (idx !== -1) {
+    mockDb.users.splice(idx, 1)
+    return { success: true }
+  }
+  return { success: false, error: 'User not found' }
 }
 
 export async function createUser(data: { email: string; password: string; role: string }): Promise<ActionResult<{ user: User }>> {
-  return { success: true, user: mockUsers[0] }
+  const newUser: User = {
+    id: String(mockDb.users.length + 1),
+    email: data.email,
+    password: data.password,
+    role: data.role as any,
+    created_at: new Date().toISOString(),
+  }
+  mockDb.users.push(newUser)
+  return { success: true, user: newUser }
 }
 
-export async function updateUser(id: string, updates: { email?: string; password?: string; user_metadata?: { role: string } }): Promise<ActionResult<{ user: User }>> {
-  return { success: true, user: mockUsers[0] }
+export async function updateUser(
+  id: string,
+  updates: { email?: string; password?: string; user_metadata?: { role: string } },
+): Promise<ActionResult<{ user: User | null }>> {
+  const user = mockDb.users.find(u => u.id === id) || null
+  if (user) {
+    Object.assign(user, updates)
+    if (updates.user_metadata?.role) user.role = updates.user_metadata.role as any
+    return { success: true, user }
+  }
+  return { success: false, user: null, error: 'User not found' }
 }

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import Image from "next/image"
+import { mockDb } from "@/lib/mockDb"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -10,6 +11,7 @@ import { Building, Users, Award, Globe, Shield, CheckCircle, Star, Target, Heart
 import { AnimatedCounter, FadeInSection, SlideInSection } from "@/components/AnimatedComponents"
 
 export default function AboutPage() {
+  const about = mockDb.content.about
   const [activeTab, setActiveTab] = useState("company")
 
   const stats = [
@@ -176,17 +178,9 @@ export default function AboutPage() {
         <div className="container mx-auto px-4 relative z-10">
           <div className="max-w-4xl mx-auto text-center">
             <FadeInSection>
-              <h1 className="text-4xl lg:text-6xl font-bold mb-6 font-sarabun">
-                เกี่ยวกับเรา
-              </h1>
-              <p className="text-xl lg:text-2xl mb-8 text-blue-100 font-sarabun">
-                KDP Engineering & Supply จำกัด
-              </p>
-              <p className="text-lg text-blue-200 font-sarabun max-w-3xl mx-auto">
-                ผู้นำด้านการจำหน่ายอุปกรณ์ไฟฟ้าอุตสาหกรรมคุณภาพสูง 
-                ด้วยประสบการณ์กว่า 15 ปี และความเป็นตัวแทนจำหน่าย O-Z/Gedney อย่างเป็นทางการ
-              </p>
-            </FadeInSection>
+              <h1 className="text-4xl lg:text-6xl font-bold mb-6 font-sarabun">{about.title}</h1>
+              <p className="text-xl lg:text-2xl mb-8 text-blue-100 font-sarabun">{about.body}</p>
+              </FadeInSection>
           </div>
         </div>
       </section>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge"
 import { Phone, Mail, MapPin, Clock, Send, MessageCircle, Building, Users, Globe, CheckCircle } from 'lucide-react'
 import { FadeInSection, SlideInSection } from "@/components/AnimatedComponents"
+import { addLead } from "@/actions/leads"
 import { useToast } from "@/hooks/use-toast"
 import { fbPixelTrack } from "@/components/FacebookPixel"
 
@@ -32,28 +33,28 @@ export default function ContactPage() {
     setIsSubmitting(true)
 
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 2000))
-      
-      // Track lead conversion
-      fbPixelTrack.lead("Contact Form")
-      
-      toast({
-        title: "ส่งข้อความสำเร็จ!",
-        description: "ขอบคุณสำหรับการติดต่อ เราจะติดต่อกลับภายใน 24 ชั่วโมง",
-      })
-
-      // Reset form
-      setFormData({
-        name: "",
-        company: "",
-        phone: "",
-        email: "",
-        subject: "",
-        message: "",
-        productInterest: "",
-        urgency: ""
-      })
+      const fd = new FormData()
+      Object.entries(formData).forEach(([k, v]) => fd.append(k, v))
+      const res = await addLead(fd)
+      if (res.success) {
+        fbPixelTrack.lead("Contact Form")
+        toast({
+          title: "ส่งข้อความสำเร็จ!",
+          description: "ขอบคุณสำหรับการติดต่อ เราจะติดต่อกลับภายใน 24 ชั่วโมง",
+        })
+        setFormData({
+          name: "",
+          company: "",
+          phone: "",
+          email: "",
+          subject: "",
+          message: "",
+          productInterest: "",
+          urgency: ""
+        })
+      } else {
+        toast({ title: "เกิดข้อผิดพลาด", description: res.error || "ไม่สามารถบันทึกข้อมูลได้", variant: "destructive" })
+      }
     } catch (error) {
       toast({
         title: "เกิดข้อผิดพลาด",

--- a/lib/mockDb.ts
+++ b/lib/mockDb.ts
@@ -1,0 +1,58 @@
+import { mockProducts } from './mock/products'
+import { mockOrders, MockOrder } from './mock/orders'
+import { mockUsers, User } from './mock/users'
+import { mockLeads, Lead } from './mock/leads'
+import { Product } from '@/types/product'
+
+export interface Payment {
+  id: string
+  order_id: string
+  amount: number
+  status: 'pending' | 'succeeded' | 'failed'
+  method?: string
+  created_at: string
+}
+
+export interface ShippingInfo {
+  order_id: string
+  status: string
+  tracking_number?: string
+  updated_at: string
+}
+
+export interface MockDb {
+  products: Product[]
+  orders: MockOrder[]
+  users: User[]
+  leads: Lead[]
+  payments: Payment[]
+  shipping: ShippingInfo[]
+  analytics: {
+    totalSales: number
+    totalUsers: number
+    totalOrders: number
+  }
+  content: {
+    about: { title: string; body: string }
+  }
+}
+
+export const mockDb: MockDb = {
+  products: mockProducts,
+  orders: mockOrders,
+  users: mockUsers,
+  leads: mockLeads,
+  payments: [],
+  shipping: [],
+  analytics: {
+    totalSales: mockOrders.reduce((sum, o) => sum + o.total_amount, 0),
+    totalUsers: mockUsers.length,
+    totalOrders: mockOrders.length,
+  },
+  content: {
+    about: {
+      title: 'About Our Store (Mock)',
+      body: 'This content is served from the mock database. Swap with real data in production.',
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add `mockDb` providing unified in-memory mock storage for products, orders, users, leads, payments and analytics
- refactor server actions to read/write from `mockDb` and simulate CRUD operations
- wire contact form and about page to pull and push mock data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895440fdc548325af61c29756143d3a