### PR TITLE
feat: centralize mock data for testable store flow

### DIFF
--- a/__tests__/orders.test.ts
+++ b/__tests__/orders.test.ts
@@ -1,10 +1,10 @@
 import { fetchOrders, createOrder, updateOrderStatus } from '@/actions/orders'
-import { mockOrders } from '@/lib/mock/orders'
+import { mockDb } from '@/lib/mockDb'
 
 describe('orders actions', () => {
   test('fetchOrders returns mock data', async () => {
     const result = await fetchOrders(1,10)
-    expect(result).toEqual({ orders: mockOrders, totalCount: mockOrders.length, error: null })
+    expect(result).toEqual({ orders: mockDb.orders, totalCount: mockDb.orders.length, error: null })
   })
 
   test('createOrder returns success', async () => {

--- a/__tests__/products.test.ts
+++ b/__tests__/products.test.ts
@@ -1,10 +1,10 @@
 import { fetchProducts, addProduct } from '@/actions/products'
-import { mockProducts } from '@/lib/mock/products'
+import { mockDb } from '@/lib/mockDb'
 
 describe('products actions', () => {
   test('fetchProducts returns mock data', async () => {
     const result = await fetchProducts(1, 10)
-    expect(result).toEqual({ products: mockProducts, totalCount: mockProducts.length, error: null })
+    expect(result).toEqual({ products: mockDb.products, totalCount: mockDb.products.length, error: null })
   })
 
   test('addProduct returns success', async () => {

--- a/actions/analytics.ts
+++ b/actions/analytics.ts
@@ -1,8 +1,6 @@
 'use server'
 
-import { mockOrders } from '@/lib/mock/orders'
-import { mockUsers } from '@/lib/mock/users'
-import { mockProducts } from '@/lib/mock/products'
+import { mockDb } from '@/lib/mockDb'
 
 export interface SalesSummaryPoint {
   date: string
@@ -26,21 +24,21 @@ function isWithinRange(date: string, start: string, end: string) {
 }
 
 export async function getSalesSummaryRange(start: string, end: string) {
-  const summary = mockOrders
+  const summary = mockDb.orders
     .filter(o => isWithinRange(o.created_at, start, end))
     .map(o => ({ date: o.created_at.split('T')[0], total: o.total_amount }))
   return { summary, error: null }
 }
 
 export async function getUserGrowthTrendRange(start: string, end: string) {
-  const trend = mockUsers
+  const trend = mockDb.users
     .filter(u => isWithinRange(u.created_at, start, end))
     .map(u => ({ date: u.created_at.split('T')[0], count: 1 }))
   return { trend, error: null }
 }
 
 export async function getDailyOrderCountsRange(start: string, end: string) {
-  const counts = mockOrders
+  const counts = mockDb.orders
     .filter(o => isWithinRange(o.created_at, start, end))
     .map(o => ({ date: o.created_at.split('T')[0], count: 1 }))
   return { counts, error: null }
@@ -48,7 +46,7 @@ export async function getDailyOrderCountsRange(start: string, end: string) {
 
 export async function getTopProducts(start: string, end: string, limit: number) {
   const totals: Record<string, number> = {}
-  mockOrders
+  mockDb.orders
     .filter(o => isWithinRange(o.created_at, start, end))
     .forEach(o => {
       o.order_items?.forEach(item => {
@@ -57,7 +55,7 @@ export async function getTopProducts(start: string, end: string, limit: number) 
     })
   const products = Object.entries(totals)
     .map(([id, qty]) => {
-      const product = mockProducts.find(p => p.id === id)
+      const product = mockDb.products.find(p => p.id === id)
       return { id, name: product?.name || 'Unknown', totalSold: qty }
     })
     .sort((a, b) => b.totalSold - a.totalSold)

--- a/actions/leads.ts
+++ b/actions/leads.ts
@@ -1,29 +1,56 @@
 'use server'
 
-import { mockLeads, Lead } from '@/lib/mock/leads'
+import { mockDb, Lead } from '@/lib/mockDb'
 
 export async function fetchLeads(): Promise<Lead[]> {
-  return mockLeads
+  return mockDb.leads
 }
 
 type ActionResult = { success: boolean; error?: string }
 
 export async function addLead(formData: FormData): Promise<ActionResult> {
+  const lead: Lead = {
+    id: String(mockDb.leads.length + 1),
+    email: formData.get('email') as string,
+    customer_name: formData.get('customer_name') as string,
+    phone: formData.get('phone') as string,
+    product_interest: formData.get('product_interest') as string,
+    status: 'รอติดต่อ',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    notes: [],
+    company: formData.get('company') as string | undefined,
+    size: formData.get('size') as string | undefined,
+    quantity: formData.get('quantity') as string | undefined,
+    address: formData.get('address') as string | undefined,
+  }
+  mockDb.leads.push(lead)
   return { success: true }
 }
 
 export async function deleteLead(id: string): Promise<ActionResult> {
+  const index = mockDb.leads.findIndex(l => l.id === id)
+  if (index === -1) return { success: false, error: 'Lead not found' }
+  mockDb.leads.splice(index, 1)
   return { success: true }
 }
 
 export async function fetchLeadCount(): Promise<number> {
-  return mockLeads.length
+  return mockDb.leads.length
 }
 
 export async function updateLeadStatus(id: string, status: string): Promise<ActionResult> {
+  const lead = mockDb.leads.find(l => l.id === id)
+  if (!lead) return { success: false, error: 'Lead not found' }
+  lead.status = status as Lead['status']
+  lead.updated_at = new Date().toISOString()
   return { success: true }
 }
 
 export async function addNoteToLead(id: string, note: string): Promise<ActionResult> {
+  const lead = mockDb.leads.find(l => l.id === id)
+  if (!lead) return { success: false, error: 'Lead not found' }
+  lead.notes = [...(lead.notes || []), note]
+  lead.updated_at = new Date().toISOString()
   return { success: true }
 }

--- a/actions/products.ts
+++ b/actions/products.ts
@@ -1,38 +1,55 @@
 'use server'
 
-import { mockProducts } from '@/lib/mock/products'
+import { mockDb } from '@/lib/mockDb'
 import { Product } from '@/types/product'
 
 export async function fetchProducts(page: number = 1, limit: number = 10) {
   const offset = (page - 1) * limit
-  const products = mockProducts.slice(offset, offset + limit)
-  return { products, totalCount: mockProducts.length, error: null }
+  const products = mockDb.products.slice(offset, offset + limit)
+  return { products, totalCount: mockDb.products.length, error: null }
 }
 
 export async function fetchProductBySlug(slug: string) {
-  const product = mockProducts.find(p => p.slug === slug) || null
+  const product = mockDb.products.find(p => p.slug === slug) || null
   return { product, error: null }
 }
 
 export async function fetchProductCount() {
-  return { count: mockProducts.length, error: null }
+  return { count: mockDb.products.length, error: null }
 }
 
 export async function fetchRecentProducts(limit: number) {
-  return { products: mockProducts.slice(0, limit), error: null }
+  return { products: mockDb.products.slice(0, limit), error: null }
 }
 
 type ActionResult<T = {}> = { success: boolean; error?: string } & T
 
-export async function addProduct(productData: Omit<Product, 'id' | 'created_at' | 'updated_at'>): Promise<ActionResult<{ product: Product }>> {
-  return { success: true, product: { ...productData, id: 'new', created_at: '', updated_at: '' } as Product }
+export async function addProduct(
+  productData: Omit<Product, 'id' | 'created_at' | 'updated_at'>
+): Promise<ActionResult<{ product: Product }>> {
+  const product: Product = {
+    ...productData,
+    id: String(mockDb.products.length + 1),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+  mockDb.products.push(product)
+  return { success: true, product }
 }
 
-export async function updateProduct(id: string, productData: Partial<Omit<Product, 'id' | 'created_at'>>): Promise<ActionResult<{ product: Product | null }>> {
-  const product = mockProducts.find(p => p.id === id) || null
+export async function updateProduct(
+  id: string,
+  productData: Partial<Omit<Product, 'id' | 'created_at'>>
+): Promise<ActionResult<{ product: Product | null }>> {
+  const product = mockDb.products.find(p => p.id === id)
+  if (!product) return { success: false, error: 'Product not found', product: null }
+  Object.assign(product, productData, { updated_at: new Date().toISOString() })
   return { success: true, product }
 }
 
 export async function deleteProduct(id: string): Promise<ActionResult> {
+  const index = mockDb.products.findIndex(p => p.id === id)
+  if (index === -1) return { success: false, error: 'Product not found' }
+  mockDb.products.splice(index, 1)
   return { success: true }
 }

--- a/actions/users.ts
+++ b/actions/users.ts
@@ -1,19 +1,19 @@
 'use server'
 
-import { mockUsers, User } from '@/lib/mock/users'
+import { mockDb, User } from '@/lib/mockDb'
 
 export async function fetchUsers(page: number = 1, limit: number = 10): Promise<{ users: User[]; totalCount: number; error: null }> {
   const offset = (page - 1) * limit
-  const users = mockUsers.slice(offset, offset + limit)
-  return { users, totalCount: mockUsers.length, error: null }
+  const users = mockDb.users.slice(offset, offset + limit)
+  return { users, totalCount: mockDb.users.length, error: null }
 }
 
 export async function fetchUserCount() {
-  return { count: mockUsers.length, error: null }
+  return { count: mockDb.users.length, error: null }
 }
 
 export async function fetchRecentUsers(limit: number): Promise<{ users: User[]; error: null }> {
-  return { users: mockUsers.slice(0, limit), error: null }
+  return { users: mockDb.users.slice(0, limit), error: null }
 }
 
 type ActionResult<T = {}> = { success: boolean; error?: string } & T
@@ -23,13 +23,36 @@ export async function updateUserRole(): Promise<ActionResult<{ user: User | null
 }
 
 export async function deleteUser(id: string): Promise<ActionResult> {
+  const index = mockDb.users.findIndex(u => u.id === id)
+  if (index === -1) return { success: false, error: 'User not found' }
+  mockDb.users.splice(index, 1)
   return { success: true }
 }
 
 export async function createUser(data: { email: string; password: string; role: string }): Promise<ActionResult<{ user: User }>> {
-  return { success: true, user: mockUsers[0] }
+  const user: User = {
+    id: String(mockDb.users.length + 1),
+    email: data.email,
+    created_at: new Date().toISOString(),
+    last_sign_in_at: null,
+    email_confirmed_at: null,
+    role: 'authenticated',
+    app_metadata: {},
+    user_metadata: { role: data.role },
+  }
+  mockDb.users.push(user)
+  return { success: true, user }
 }
 
-export async function updateUser(id: string, updates: { email?: string; password?: string; user_metadata?: { role: string } }): Promise<ActionResult<{ user: User }>> {
-  return { success: true, user: mockUsers[0] }
+export async function updateUser(
+  id: string,
+  updates: { email?: string; password?: string; user_metadata?: { role: string } }
+): Promise<ActionResult<{ user: User }>> {
+  const user = mockDb.users.find(u => u.id === id)
+  if (!user) return { success: false, error: 'User not found' }
+  Object.assign(user, updates)
+  if (updates.user_metadata) {
+    user.user_metadata = { ...user.user_metadata, ...updates.user_metadata }
+  }
+  return { success: true, user }
 }

--- a/app/admin/leads/page.tsx
+++ b/app/admin/leads/page.tsx
@@ -19,7 +19,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Eye, Download } from 'lucide-react'
 import { useAuthStore } from "@/lib/store" // Keep useAuthStore for client-side auth state
 import { fetchLeads, updateLeadStatus, addNoteToLead } from "@/actions/leads" // Import new Server Actions
-import type { Lead } from "@/lib/mock/leads"
+import type { Lead } from "@/lib/mockDb"
 
 export default function AdminLeads() {
   const router = useRouter()

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -21,7 +21,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Plus, Edit, Trash2, Mail, KeyRound } from 'lucide-react'
 import { useAuthStore } from "@/lib/store"
 import { fetchUsers, createUser, updateUser, deleteUser } from "@/actions/users"
-import type { User } from "@/lib/mock/users"
+import type { User } from "@/lib/mockDb"
 
 export default function AdminUsers() {
   const router = useRouter()

--- a/app/order/page.tsx
+++ b/app/order/page.tsx
@@ -12,7 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { ShoppingCart, Plus, Minus, Trash2 } from "lucide-react"
-import { products } from "@/lib/mockData"
+import { mockDb } from "@/lib/mockDb"
 
 interface CartItem {
   productId: string
@@ -38,7 +38,7 @@ export default function OrderPage() {
 
   useEffect(() => {
     if (productSlug) {
-      const product = products.find((p) => p.slug === productSlug)
+      const product = mockDb.products.find((p) => p.slug === productSlug)
       if (product && product.sizes.length > 0) {
         addToCart(product.id, product.name, product.sizes[0], product.base_price)
       }
@@ -127,7 +127,7 @@ export default function OrderPage() {
             </CardHeader>
             <CardContent>
               <div className="space-y-4">
-                {products.map((product) => (
+                {mockDb.products.map((product) => (
                   <div key={product.id} className="border rounded-lg p-4">
                     <div className="flex justify-between items-start mb-2">
                       <div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,13 +11,13 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Search, Phone, Mail, MapPin, CheckCircle, Shield, Award, Users, Clock, Star, Truck } from "lucide-react"
-import { products } from "@/lib/mockData"
+import { mockDb } from "@/lib/mockDb"
 import { AnimatedCounter, FadeInSection, SlideInSection } from "@/components/AnimatedComponents"
 import { useToast } from "@/hooks/use-toast"
 
 export default function HomePage() {
   const [searchTerm, setSearchTerm] = useState("")
-  const [featuredProducts, setFeaturedProducts] = useState(products.slice(0, 8))
+  const [featuredProducts, setFeaturedProducts] = useState(mockDb.products.slice(0, 8))
   const [contactForm, setContactForm] = useState({
     name: "",
     company: "",
@@ -34,8 +34,8 @@ export default function HomePage() {
       product.type?.toLowerCase().includes(searchTerm.toLowerCase()),
   )
 
-  const productTypes = [...new Set(products.map((p) => p.type).filter(Boolean))]
-  const totalProducts = products.length
+  const productTypes = [...new Set(mockDb.products.map((p) => p.type).filter(Boolean))]
+  const totalProducts = mockDb.products.length
 
   const handleContactSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -175,7 +175,7 @@ export default function HomePage() {
                       </div>
                       <h3 className="font-semibold text-sm font-sarabun">{type}</h3>
                       <p className="text-xs text-gray-500 mt-1">
-                        {products.filter((p) => p.type === type).length} รายการ
+                        {mockDb.products.filter((p) => p.type === type).length} รายการ
                       </p>
                     </CardContent>
                   </Card>

--- a/lib/mockDb.ts
+++ b/lib/mockDb.ts
@@ -1,0 +1,172 @@
+import { Product } from '@/types/product'
+
+export interface MockOrderItem {
+  id: string
+  product_id: string
+  quantity: number
+  price: number
+  product_name?: string
+  price_at_purchase?: number
+}
+
+export interface MockOrder {
+  id: string
+  user_id: string
+  total_amount: number
+  status: string
+  payment_status: 'paid' | 'unpaid' | 'refunded'
+  created_at: string
+  order_items?: MockOrderItem[]
+  notes?: string
+  shipping_address?: {
+    name: string
+    address_line1: string
+    address_line2?: string
+    city: string
+    state: string
+    zip_code: string
+    country?: string
+    phone?: string
+  }
+}
+
+export interface User {
+  id: string
+  email: string
+  created_at: string
+  last_sign_in_at: string | null
+  email_confirmed_at: string | null
+  role: string | null
+  app_metadata: Record<string, any>
+  user_metadata: { role?: string; [key: string]: any }
+}
+
+export interface Lead {
+  id: string
+  email: string
+  customer_name: string
+  phone: string
+  product_interest: string
+  status: 'รอติดต่อ' | 'กำลังเจรจา' | 'ปิดการขาย'
+  created_at: string
+  updated_at: string
+  notes?: string[]
+  company?: string
+  size?: string
+  quantity?: string
+  address?: string
+}
+
+export interface Payment {
+  id: string
+  orderId: string
+  amount: number
+  status: 'pending' | 'succeeded' | 'failed'
+}
+
+export interface Shipping {
+  orderId: string
+  status: 'pending' | 'shipped' | 'delivered'
+  trackingNumber?: string
+}
+
+export const mockDb = {
+  products: [
+    {
+      id: '1',
+      name: 'Mock Product A',
+      slug: 'mock-product-a',
+      description: 'Mock product A description',
+      type: 'A',
+      material: 'Aluminum',
+      sizes: ['1/2', '3/4'],
+      base_price: 100,
+      category: 'Standard',
+      image_url: '',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      stock_quantity: 10,
+    },
+    {
+      id: '2',
+      name: 'Mock Product B',
+      slug: 'mock-product-b',
+      description: 'Mock product B description',
+      type: 'B',
+      material: 'Steel',
+      sizes: ['1'],
+      base_price: 200,
+      category: 'Standard',
+      image_url: '',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      stock_quantity: 5,
+    },
+  ] as Product[],
+  orders: [
+    {
+      id: '1',
+      user_id: '1',
+      total_amount: 300,
+      status: 'pending',
+      payment_status: 'unpaid',
+      created_at: new Date().toISOString(),
+      order_items: [
+        { id: '1', product_id: '1', quantity: 1, price: 100, product_name: 'Mock Product A', price_at_purchase: 100 },
+        { id: '2', product_id: '2', quantity: 1, price: 200, product_name: 'Mock Product B', price_at_purchase: 200 },
+      ],
+      notes: '',
+      shipping_address: {
+        name: 'Mock Customer',
+        address_line1: '123 Mock St',
+        city: 'Bangkok',
+        state: '',
+        zip_code: '10000',
+        country: 'TH',
+        phone: '000-0000',
+      },
+    },
+  ] as MockOrder[],
+  users: [
+    {
+      id: '1',
+      email: 'alice@example.com',
+      created_at: new Date().toISOString(),
+      last_sign_in_at: null,
+      email_confirmed_at: null,
+      role: 'authenticated',
+      app_metadata: {},
+      user_metadata: { role: 'admin' },
+    },
+    {
+      id: '2',
+      email: 'bob@example.com',
+      created_at: new Date().toISOString(),
+      last_sign_in_at: null,
+      email_confirmed_at: null,
+      role: 'authenticated',
+      app_metadata: {},
+      user_metadata: { role: 'viewer' },
+    },
+  ] as User[],
+  leads: [
+    {
+      id: '1',
+      email: 'lead@example.com',
+      customer_name: 'Mock Lead',
+      phone: '000-0000',
+      product_interest: 'Mock Product A',
+      status: 'รอติดต่อ',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      notes: [],
+      company: 'Mock Company',
+      size: '',
+      quantity: '',
+    },
+  ] as Lead[],
+  payments: [] as Payment[],
+  shipping: [] as Shipping[],
+}
+
+export type MockDb = typeof mockDb


### PR DESCRIPTION
## Summary
- add `lib/mockDb` with unified mock products, orders, users, leads, payments, and shipping
- refactor server actions to read/write from mock database
- update pages and tests to rely on new mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895483a1a208325ae087c4e85701b96