### PR TITLE
Align mock data modules and fix admin user page

### DIFF
--- a/__tests__/orders-test.ts
+++ b/__tests__/orders-test.ts
@@ -1,5 +1,6 @@
 import { fetchOrders, createOrder, updateOrderStatus } from '@/actions/orders'
-import { mockOrders } from '@/lib/mockDb'
+// Align the test data with the orders module used by actions
+import { mockOrders } from '@/lib/mock/orders'
 
 describe('orders actions', () => {
   test('fetchOrders returns mock data', async () => {

--- a/actions/orders.ts
+++ b/actions/orders.ts
@@ -1,11 +1,8 @@
 
-import {
-  mockOrders,
-  mockPayments,
-  mockShippings,
-  MockOrder,
-  MockOrderItem,
-} from '@/lib/mockDb'
+// Use the standalone mock orders so tests reference the same data instance
+import { mockOrders, MockOrder, MockOrderItem } from '@/lib/mock/orders'
+// Payments and shippings remain in the shared mock database
+import { mockPayments, mockShippings } from '@/lib/mockDb'
 
 export interface OrderItem
   extends Omit<MockOrderItem, 'price_at_purchase'> {
@@ -43,7 +40,7 @@ export async function createOrder(
   userId: string,
   totalAmount: number,
   cartItems: CartItem[],
-  shipping: {
+  shipping?: {
     address: string
     city: string
     state: string
@@ -58,14 +55,23 @@ export async function createOrder(
   // Construct a shipping address object compatible with the MockOrder type.  Name
   // and address line2 are omitted because they are not collected in the
   // checkout form. If needed, these fields can be added later.
-  const shippingAddress = {
-    name: '',
-    address_line1: shipping.address,
-    city: shipping.city,
-    state: shipping.state,
-    zip_code: shipping.zip,
-    country: shipping.country,
-  }
+  const shippingAddress = shipping
+    ? {
+        name: '',
+        address_line1: shipping.address,
+        city: shipping.city,
+        state: shipping.state,
+        zip_code: shipping.zip,
+        country: shipping.country,
+      }
+    : {
+        name: '',
+        address_line1: '',
+        city: '',
+        state: '',
+        zip_code: '',
+        country: '',
+      }
   const order: Order = {
     id: newId,
     user_id: userId,

--- a/actions/products.ts
+++ b/actions/products.ts
@@ -1,5 +1,6 @@
 
-import { mockProducts } from '@/lib/mockDb'
+// Use the standalone mock products so tests reference the same data instance
+import { mockProducts } from '@/lib/mock/products'
 import { Product } from '@/types/product'
 
 export async function fetchProducts(page: number = 1, limit: number = 10) {

--- a/app/admin/users/admin-users-page.tsx
+++ b/app/admin/users/admin-users-page.tsx
@@ -275,10 +275,12 @@ export default function AdminUsers() {
                 </div>
               </form>
             </DialogContent>
-          </Dialog>
-        </div>
+            </Dialog>
+          </div>
+          {/* Close header wrapper */}
+          </div>
 
-        <Card>
+          <Card>
           <CardHeader>
             <CardTitle className="font-sarabun">รายการผู้ใช้</CardTitle>
             <CardDescription className="font-sarabun">จำนวนผู้ใช้ทั้งหมด: {users.length} รายการ</CardDescription>


### PR DESCRIPTION
## Summary
- use standalone mock products and orders for consistent tests
- allow createOrder to accept optional shipping details
- fix admin users page markup and lint error

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6895ab4385208325ad92086695afcbb3