### PR TITLE
fix: define metadata base for open graph images

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
   title: "O-Z/Gedney Conduit Body | KDP Engineering & Supply",
   description: "ผู้จำหน่าย O-Z/Gedney Conduit Body คุณภาพสูง มาตรฐาน UL และ NEMA สำหรับงานไฟฟ้าอุตสาหกรรม",
   keywords: "conduit body, O-Z Gedney, KDP Engineering, อุปกรณ์ไฟฟ้า, อุตสาหกรรม",
+  metadataBase: new URL("https://kdp-conduit.vercel.app"),
   openGraph: {
     title: "O-Z/Gedney Conduit Body | KDP Engineering & Supply",
     description: "ผู้จำหน่าย O-Z/Gedney Conduit Body คุณภาพสูง มาตรฐาน UL และ NEMA",


### PR DESCRIPTION
## Summary
- set `metadataBase` so Next.js can resolve Open Graph and Twitter image URLs correctly

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895df57dfa483258b5dbf2e4e10bf3e