### PR TITLE
feat: create product service and API route

### DIFF
--- a/__tests__/products.test.ts
+++ b/__tests__/products.test.ts
@@ -1,5 +1,5 @@
 import { fetchProducts, addProduct } from '@/actions/products'
-import { mockProducts } from '@/lib/mock/products'
+import { mockProducts } from '@/lib/mockDb'
 
 describe('products actions', () => {
   test('fetchProducts returns mock data', async () => {

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import * as productService from '@/lib/services/products'
+
+const productSchema = z.object({
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().optional(),
+  base_price: z.number(),
+  image_url: z.string().optional(),
+  category: z.string().optional(),
+  type: z.string().optional(),
+  material: z.string().optional(),
+  sizes: z.array(z.string()),
+  is_featured: z.boolean().optional(),
+  stock_quantity: z.number(),
+  tags: z.array(z.string()).optional(),
+  discount_price: z.number().optional(),
+  sale_start_date: z.string().optional(),
+  sale_end_date: z.string().optional()
+})
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const page = parseInt(searchParams.get('page') || '1', 10)
+  const limit = parseInt(searchParams.get('limit') || '10', 10)
+  const data = productService.listProducts(page, limit)
+  return NextResponse.json(data)
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const json = await req.json()
+    const parsed = productSchema.parse(json)
+    const product = productService.addProduct(parsed)
+    return NextResponse.json({ success: true, product })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
+    console.error('Product creation error', error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/lib/services/products.ts
+++ b/lib/services/products.ts
@@ -1,0 +1,49 @@
+import { mockProducts } from '@/lib/mockDb'
+import { Product } from '@/types/product'
+
+export function listProducts(page: number = 1, limit: number = 10) {
+  const offset = (page - 1) * limit
+  const products = mockProducts.slice(offset, offset + limit)
+  return { products, totalCount: mockProducts.length }
+}
+
+export function getProductBySlug(slug: string) {
+  return mockProducts.find((p) => p.slug === slug) || null
+}
+
+export function getProductCount() {
+  return mockProducts.length
+}
+
+export function getRecentProducts(limit: number) {
+  return mockProducts.slice(0, limit)
+}
+
+type ProductInput = Omit<Product, 'id' | 'created_at' | 'updated_at'>
+
+export function addProduct(productData: ProductInput): Product {
+  const newId = (mockProducts.length + 1).toString()
+  const now = new Date().toISOString()
+  const newProduct: Product = { id: newId, created_at: now, updated_at: now, ...productData }
+  mockProducts.push(newProduct)
+  return newProduct
+}
+
+export function updateProduct(
+  id: string,
+  productData: Partial<Omit<Product, 'id' | 'created_at'>>
+): Product | null {
+  const idx = mockProducts.findIndex((p) => p.id === id)
+  if (idx === -1) return null
+  const existing = mockProducts[idx]
+  const updated: Product = { ...existing, ...productData, updated_at: new Date().toISOString() }
+  mockProducts[idx] = updated
+  return updated
+}
+
+export function deleteProduct(id: string): boolean {
+  const idx = mockProducts.findIndex((p) => p.id === id)
+  if (idx === -1) return false
+  mockProducts.splice(idx, 1)
+  return true
+}


### PR DESCRIPTION
## Summary
- add product service backed by mock database
- expose `/api/products` with validation for listing and creating products
- update product actions and tests to use service

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689625c1eaf48325b2a89046ba253af8