### PR TITLE
Implement basic login authentication

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -13,18 +13,21 @@ export async function signIn({
   password: string
 }) {
   if (email === AUTH_EMAIL && password === AUTH_PASSWORD) {
-    cookies().set('session', 'authenticated', { httpOnly: true })
+    const cookieStore = await cookies()
+    cookieStore.set('session', 'authenticated', { httpOnly: true })
     return { id: '1', email }
   }
   return null
 }
 
 export async function signOut() {
-  cookies().delete('session')
+  const cookieStore = await cookies()
+  cookieStore.delete('session')
 }
 
 export async function getSession() {
-  const session = cookies().get('session')
+  const cookieStore = await cookies()
+  const session = cookieStore.get('session')
   if (session?.value === 'authenticated') {
     return { user: { id: '1', email: AUTH_EMAIL } }
   }

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -1,15 +1,32 @@
 'use server'
 
-import { redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
 
-export async function signIn(formData: FormData) {
-  redirect('/admin')
+const AUTH_EMAIL = 'admin@example.com'
+const AUTH_PASSWORD = 'password123'
+
+export async function signIn({
+  email,
+  password,
+}: {
+  email: string
+  password: string
+}) {
+  if (email === AUTH_EMAIL && password === AUTH_PASSWORD) {
+    cookies().set('session', 'authenticated', { httpOnly: true })
+    return { id: '1', email }
+  }
+  return null
 }
 
 export async function signOut() {
-  redirect('/admin/login')
+  cookies().delete('session')
 }
 
 export async function getSession() {
-  return { user: { id: '1', email: 'mock@example.com' } }
+  const session = cookies().get('session')
+  if (session?.value === 'authenticated') {
+    return { user: { id: '1', email: AUTH_EMAIL } }
+  }
+  return null
 }

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,15 +1,77 @@
 "use client"
 
-import { useEffect } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAuthStore } from "@/lib/store"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 
 export default function AdminLogin() {
   const router = useRouter()
   const login = useAuthStore((s) => s.login)
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const [credentials, setCredentials] = useState({ email: "", password: "" })
+
   useEffect(() => {
-    login()
-    router.push("/admin")
-  }, [login, router])
-  return null
+    if (isAuthenticated) {
+      router.push("/admin")
+    }
+  }, [isAuthenticated, router])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const success = await login(credentials.email, credentials.password)
+    if (success) {
+      router.push("/admin")
+    } else {
+      alert("อีเมลหรือรหัสผ่านไม่ถูกต้อง")
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 rounded bg-white p-6 shadow"
+      >
+        <div>
+          <Label htmlFor="email" className="font-sarabun">
+            อีเมล
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            value={credentials.email}
+            onChange={(e) =>
+              setCredentials((prev) => ({ ...prev, email: e.target.value }))
+            }
+            required
+            className="font-sarabun"
+            placeholder="admin@example.com"
+          />
+        </div>
+        <div>
+          <Label htmlFor="password" className="font-sarabun">
+            รหัสผ่าน
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            value={credentials.password}
+            onChange={(e) =>
+              setCredentials((prev) => ({ ...prev, password: e.target.value }))
+            }
+            required
+            className="font-sarabun"
+            placeholder="password123"
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          เข้าสู่ระบบ
+        </Button>
+      </form>
+    </div>
+  )
 }
+

--- a/components/LoginDialog.tsx
+++ b/components/LoginDialog.tsx
@@ -30,10 +30,14 @@ export function LoginDialog({ children }: LoginDialogProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    login()
-    setIsOpen(false)
-    router.push("/admin")
-    toast({ title: "เข้าสู่ระบบสำเร็จ" })
+    const success = await login(credentials.email, credentials.password)
+    if (success) {
+      setIsOpen(false)
+      router.push("/admin")
+      toast({ title: "เข้าสู่ระบบสำเร็จ" })
+    } else {
+      toast({ title: "อีเมลหรือรหัสผ่านไม่ถูกต้อง", variant: "destructive" })
+    }
   }
 
   return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,20 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export async function middleware(req: NextRequest) {
+export function middleware(req: NextRequest) {
+  const session = req.cookies.get('session')?.value === 'authenticated'
+  const isLoginPage = req.nextUrl.pathname === '/admin/login'
+
+  if (!session && !isLoginPage) {
+    const loginUrl = new URL('/admin/login', req.url)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  if (session && isLoginPage) {
+    const adminUrl = new URL('/admin', req.url)
+    return NextResponse.redirect(adminUrl)
+  }
+
   return NextResponse.next()
 }
 


### PR DESCRIPTION
## Summary
- add simple cookie-based auth actions
- manage auth state with Zustand store
- provide login form and middleware to guard admin routes

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68964daa3bfc8325bdc72fa6d85678ad