### PR TITLE
Add Supabase auth with admin middleware and user hooks

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -9,7 +9,7 @@ export async function signIn({
   email: string
   password: string
 }) {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const { data, error } = await supabase.auth.signInWithPassword({ email, password })
   if (error || !data.user) {
     return null
@@ -22,12 +22,12 @@ export async function signIn({
 }
 
 export async function signOut() {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   await supabase.auth.signOut()
 }
 
 export async function getSession() {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const { data } = await supabase.auth.getSession()
   return data.session
 }

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -1,9 +1,6 @@
 'use server'
 
-import { cookies } from 'next/headers'
-
-const AUTH_EMAIL = 'admin@example.com'
-const AUTH_PASSWORD = 'password123'
+import { createSupabaseServerClient } from '@/lib/supabase'
 
 export async function signIn({
   email,
@@ -12,24 +9,25 @@ export async function signIn({
   email: string
   password: string
 }) {
-  if (email === AUTH_EMAIL && password === AUTH_PASSWORD) {
-    const cookieStore = await cookies()
-    cookieStore.set('session', 'authenticated', { httpOnly: true })
-    return { id: '1', email }
+  const supabase = createSupabaseServerClient()
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+  if (error || !data.user) {
+    return null
   }
-  return null
+  return {
+    id: data.user.id,
+    email: data.user.email ?? '',
+    role: data.user.user_metadata?.role,
+  }
 }
 
 export async function signOut() {
-  const cookieStore = await cookies()
-  cookieStore.delete('session')
+  const supabase = createSupabaseServerClient()
+  await supabase.auth.signOut()
 }
 
 export async function getSession() {
-  const cookieStore = await cookies()
-  const session = cookieStore.get('session')
-  if (session?.value === 'authenticated') {
-    return { user: { id: '1', email: AUTH_EMAIL } }
-  }
-  return null
+  const supabase = createSupabaseServerClient()
+  const { data } = await supabase.auth.getSession()
+  return data.session
 }

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { createSupabaseServerClient } from '@/lib/supabase'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
 
 export async function signIn({
   email,

--- a/app/admin/logout/page.tsx
+++ b/app/admin/logout/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/lib/store'
+
+export default function AdminLogout() {
+  const router = useRouter()
+  const logout = useAuthStore((s) => s.logout)
+
+  useEffect(() => {
+    logout().then(() => {
+      router.replace('/admin/login')
+    })
+  }, [logout, router])
+
+  return <p className="p-4">Logging out...</p>
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,17 +6,15 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel,
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { ShoppingCart, User, LogOut, LayoutDashboard, History, Users, Package, BarChart3 } from 'lucide-react'
 import { useAuthStore, useCartStore } from '@/lib/store'
-import { useEffect } from 'react'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useRouter } from 'next/navigation'
 
 export function Navbar() {
-  const { isAuthenticated, user, checkAuth, logout } = useAuthStore()
+  const { logout } = useAuthStore()
+  const { user, isAdmin } = useCurrentUser()
+  const isAuthenticated = !!user
   const totalCartItems = useCartStore((state) => state.getTotalItems())
   const router = useRouter()
-
-  useEffect(() => {
-    checkAuth()
-  }, [checkAuth])
 
   const handleLogout = async () => {
     await logout()
@@ -39,7 +37,7 @@ export function Navbar() {
           <Link href="/contact" className="font-medium hover:underline font-sarabun">
             ติดต่อ
           </Link>
-          {isAuthenticated && (
+          {isAdmin && (
             <Link href="/admin" className="font-medium hover:underline font-sarabun">
               Admin
             </Link>

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { createSupabaseBrowserClient } from '@/lib/supabase'
+
+export function useCurrentUser() {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient()
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null)
+    })
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return { user, isAdmin: user?.user_metadata?.role === 'admin' }
+}

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { createSupabaseBrowserClient } from '@/lib/supabase'
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'
 
 export function useCurrentUser() {
   const [user, setUser] = useState<User | null>(null)

--- a/hooks/useRealtimeOrders.ts
+++ b/hooks/useRealtimeOrders.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { createSupabaseBrowserClient } from '@/lib/supabase'
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'
 
 export interface RealtimeOrder {
   id: string

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,6 +7,7 @@ import { signIn, signOut, getSession } from "@/actions/auth";
 interface AuthUser {
   id: string
   email: string
+  role?: string
 }
 
 interface AuthState {
@@ -36,7 +37,12 @@ export const useAuthStore = create<AuthState>()((set) => ({
   checkAuth: async () => {
     const session = await getSession()
     if (session?.user) {
-      set({ isAuthenticated: true, user: session.user })
+      const user = {
+        id: session.user.id,
+        email: session.user.email ?? '',
+        role: (session.user as any).user_metadata?.role,
+      }
+      set({ isAuthenticated: true, user })
       return true
     }
     set({ isAuthenticated: false, user: null })

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,39 +1,35 @@
-const mockClient = {
-  from: () => ({
-    select: async () => ({ data: [], error: null }),
-    insert: async () => ({ data: null, error: null }),
-    update: async () => ({ data: null, error: null }),
-    delete: async () => ({ data: null, error: null }),
-    eq: () => mockClient.from(),
-    order: () => mockClient.from(),
-    range: () => mockClient.from(),
-    limit: () => mockClient.from(),
-  }),
-  auth: {
-    signInWithPassword: async () => ({ data: { user: { id: '1', email: 'mock@example.com' } }, error: null }),
-    signOut: async () => ({ error: null }),
-    getSession: async () => ({ data: { session: null }, error: null }),
-    admin: {
-      updateUserById: async () => ({ data: { user: null }, error: null }),
-      deleteUser: async () => ({ error: null }),
-      createUser: async () => ({ data: { user: null }, error: null }),
-    },
-  },
-  storage: {
-    from: () => ({
-      upload: async () => ({ data: null, error: null }),
-      getPublicUrl: () => ({ data: { publicUrl: '' } }),
-    }),
-  },
-};
+import { createClient } from '@supabase/supabase-js'
+import { createBrowserClient, createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import type { CookieOptions } from '@supabase/ssr'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
 
 export function createSupabaseBrowserClient() {
-  return mockClient as any;
+  return createBrowserClient(supabaseUrl, supabaseAnonKey)
 }
-export const supabaseBrowser = createSupabaseBrowserClient;
+
+export const supabaseBrowser = createSupabaseBrowserClient
+
 export function createSupabaseServerClient() {
-  return mockClient as any;
+  const cookieStore = cookies()
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value
+      },
+      set(name: string, value: string, options: CookieOptions) {
+        cookieStore.set({ name, value, ...options })
+      },
+      remove(name: string, options: CookieOptions) {
+        cookieStore.delete({ name, ...options })
+      },
+    },
+  })
 }
+
 export function createSupabaseAdminClient() {
-  return mockClient as any;
+  return createClient(supabaseUrl, supabaseServiceRoleKey)
 }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+
+export function createSupabaseBrowserClient() {
+  return createBrowserClient(supabaseUrl, supabaseAnonKey)
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,17 +1,12 @@
+'use server'
+
 import { createClient } from '@supabase/supabase-js'
-import { createBrowserClient, createServerClient } from '@supabase/ssr'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
-import type { CookieOptions } from '@supabase/ssr'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-
-export function createSupabaseBrowserClient() {
-  return createBrowserClient(supabaseUrl, supabaseAnonKey)
-}
-
-export const supabaseBrowser = createSupabaseBrowserClient
 
 export function createSupabaseServerClient() {
   const cookieStore = cookies()

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-'use server'
+import 'server-only'
 
 import { createClient } from '@supabase/supabase-js'
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
@@ -8,8 +8,8 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
 
-export function createSupabaseServerClient() {
-  const cookieStore = cookies()
+export async function createSupabaseServerClient() {
+  const cookieStore = await cookies()
   return createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
       get(name: string) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,21 +1,46 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
 
-export function middleware(req: NextRequest) {
-  const session = req.cookies.get('session')?.value === 'authenticated'
-  const isLoginPage = req.nextUrl.pathname === '/admin/login'
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next({ request: { headers: req.headers } })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+    {
+      cookies: {
+        getAll() {
+          return req.cookies.getAll().map((c) => ({ name: c.name, value: c.value }))
+        },
+        setAll(cookies) {
+          cookies.forEach((c) => res.cookies.set(c.name, c.value, c.options))
+        },
+      },
+    }
+  )
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  const pathname = req.nextUrl.pathname
+  const isLoginPage = pathname === '/admin/login'
+  const isLogoutPage = pathname === '/admin/logout'
 
   if (!session && !isLoginPage) {
-    const loginUrl = new URL('/admin/login', req.url)
-    return NextResponse.redirect(loginUrl)
+    return NextResponse.redirect(new URL('/admin/login', req.url))
+  }
+
+  if (session && session.user.user_metadata?.role !== 'admin' && !isLoginPage && !isLogoutPage) {
+    return NextResponse.redirect(new URL('/admin/login', req.url))
   }
 
   if (session && isLoginPage) {
-    const adminUrl = new URL('/admin', req.url)
-    return NextResponse.redirect(adminUrl)
+    return NextResponse.redirect(new URL('/admin', req.url))
   }
 
-  return NextResponse.next()
+  return res
 }
 
 export const config = {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@stripe/react-stripe-js": "3.9.0",
     "@stripe/stripe-js": "7.8.0",
     "@supabase/auth-helpers-react": "0.5.0",
+    "@supabase/ssr": "0.6.1",
     "@supabase/supabase-js": "2.53.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@supabase/auth-helpers-react':
         specifier: 0.5.0
         version: 0.5.0(@supabase/supabase-js@2.53.0)
+      '@supabase/ssr':
+        specifier: 0.6.1
+        version: 0.6.1(@supabase/supabase-js@2.53.0)
       '@supabase/supabase-js':
         specifier: 2.53.0
         version: 2.53.0
@@ -1451,6 +1454,11 @@ packages:
   '@supabase/realtime-js@2.11.15':
     resolution: {integrity: sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==}
 
+  '@supabase/ssr@0.6.1':
+    resolution: {integrity: sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
   '@supabase/storage-js@2.10.4':
     resolution: {integrity: sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==}
 
@@ -1983,6 +1991,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5366,6 +5378,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@supabase/ssr@0.6.1(@supabase/supabase-js@2.53.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.53.0
+      cookie: 1.0.2
+
   '@supabase/storage-js@2.10.4':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -5972,6 +5989,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.0.2: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -6240,8 +6259,8 @@ snapshots:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.0.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6260,7 +6279,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -6271,22 +6290,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.0.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6297,7 +6316,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- replace mock auth with Supabase clients and role-aware actions
- gate `/admin` routes with Supabase session middleware
- add `useCurrentUser` hook, logout page, and navbar admin check

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689686e03f5c83258147ad041017199e