### PR TITLE
feat: defer facebook pixel until consent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,23 +91,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <Script id="jsonld-products" type="application/ld+json" strategy="beforeInteractive">
           {JSON.stringify(productListJsonLd)}
         </Script>
-        {process.env.NEXT_PUBLIC_FB_PIXEL_ID && (
-          <Script id="fb-pixel" strategy="afterInteractive">
-            {`
-            if (localStorage.getItem('fbPixelConsent') === 'granted') {
-              !(function(f,b,e,v,n,t,s)
-              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-              n.queue=[];t=b.createElement(e);t.async=!0;
-              t.src=v;s=b.getElementsByTagName(e)[0];
-              s.parentNode.insertBefore(t,s)})(window,document,'script',
-              'https://connect.facebook.net/en_US/fbevents.js');
-              fbq('init', '${process.env.NEXT_PUBLIC_FB_PIXEL_ID}');
-            }
-            `}
-          </Script>
-        )}
       </head>
       <body className={`${inter.className} ${sarabun.variable}`}>
         <noscript>
@@ -118,16 +101,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             style={{ display: "none", visibility: "hidden" }}
           ></iframe>
         </noscript>
-        {process.env.NEXT_PUBLIC_FB_PIXEL_ID && (
-          <noscript>
-            <img
-              height="1"
-              width="1"
-              style={{ display: "none" }}
-              src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_FB_PIXEL_ID}&ev=PageView&noscript=1`}
-            />
-          </noscript>
-        )}
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           <Navbar />
           <main className="min-h-screen">{children}</main>

--- a/components/TrackingConsent.tsx
+++ b/components/TrackingConsent.tsx
@@ -15,18 +15,20 @@ export function TrackingConsent() {
   useEffect(() => {
     const granted = hasFacebookPixelConsent()
     setConsent(granted)
-    if (granted) {
+  }, [])
+
+  useEffect(() => {
+    if (consent) {
       initFacebookPixel()
     }
-  }, [])
+  }, [consent])
 
   if (consent) return null
 
   const accept = () => {
     grantFacebookPixelConsent()
-    initFacebookPixel()
-    trackFacebookPixel("PageView")
     setConsent(true)
+    trackFacebookPixel("PageView")
   }
 
   return (

--- a/lib/facebookPixel.ts
+++ b/lib/facebookPixel.ts
@@ -10,7 +10,7 @@ const fbq = (...args: any[]) => {
 }
 
 export const initFacebookPixel = () => {
-  if (typeof window === 'undefined' || !FB_PIXEL_ID || (window as any).fbq) return
+  if (typeof window === 'undefined' || !FB_PIXEL_ID || (window as any).fbq || !hasConsent()) return
   ;(function (f: any, b: any, e: any, v: any, n?: any, t?: any, s?: any) {
     if (f.fbq) return
     n = f.fbq = function () {


### PR DESCRIPTION
## Summary
- load Facebook Pixel only after consent via `initFacebookPixel`
- call pixel initialization once user accepts tracking consent
- ensure all page events route through `trackFacebookPixel`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68971e611c28832598638bf66dc18527