### PR TITLE
feat: add orders database service

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -19,7 +19,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Label } from "@/components/ui/label"
 import { Eye, Edit, Trash2 } from 'lucide-react'
 import { useAuthStore } from "@/lib/store"
-import { fetchOrders, updateOrder, deleteOrder, Order, OrderItem, createInvoiceForOrder } from "@/actions/orders"
+import { listOrders, updateOrder, deleteOrder, createInvoiceForOrder } from "@/actions/orders"
+import { Order, OrderItem } from '@/types/order'
 import { format } from 'date-fns'
 import { th } from 'date-fns/locale'
 
@@ -47,7 +48,7 @@ export default function AdminOrders() {
     const loadOrders = async () => {
       setLoading(true)
       if (isAuthenticated) {
-        const { orders: fetchedOrders } = await fetchOrders()
+        const { orders: fetchedOrders } = await listOrders()
         setOrders(fetchedOrders)
       }
       setLoading(false)
@@ -78,7 +79,7 @@ export default function AdminOrders() {
     if (selectedOrder && newStatus) {
       const result = await updateOrder(selectedOrder.id, { status: newStatus })
       if (result.success) {
-        const { orders: fetchedOrders } = await fetchOrders()
+        const { orders: fetchedOrders } = await listOrders()
         setOrders(fetchedOrders)
         setIsEditDialogOpen(false)
         setSelectedOrder(null)
@@ -93,7 +94,7 @@ export default function AdminOrders() {
     if (confirm("คุณแน่ใจหรือไม่ที่จะลบคำสั่งซื้อนี้? การดำเนินการนี้ไม่สามารถย้อนกลับได้")) {
       const result = await deleteOrder(id)
       if (result.success) {
-        const { orders: fetchedOrders } = await fetchOrders()
+        const { orders: fetchedOrders } = await listOrders()
         setOrders(fetchedOrders)
       } else {
         alert(`Failed to delete order: ${result.error}`)
@@ -104,7 +105,7 @@ export default function AdminOrders() {
   const handleGenerateInvoice = async (id: string) => {
     const result = await createInvoiceForOrder(id)
     if (result.success) {
-      const { orders: fetchedOrders } = await fetchOrders()
+      const { orders: fetchedOrders } = await listOrders()
       setOrders(fetchedOrders)
       alert('สร้างใบแจ้งหนี้เรียบร้อย')
     } else {

--- a/lib/db/ordersDb.ts
+++ b/lib/db/ordersDb.ts
@@ -1,0 +1,117 @@
+import { sql } from '@/lib/db'
+import { Order, OrderItem } from '@/types/order'
+
+export type OrderInput = Omit<Order, 'id' | 'created_at' | 'order_items'> & {
+  order_items?: Omit<OrderItem, 'id' | 'order_id'>[]
+}
+
+async function createOrdersTables() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS orders (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id text NOT NULL,
+      total_amount numeric NOT NULL,
+      status text NOT NULL,
+      payment_status text NOT NULL,
+      created_at timestamptz DEFAULT NOW(),
+      notes text,
+      shipping_address jsonb,
+      invoice_url text,
+      invoice_id text
+    )
+  `
+  await sql`
+    CREATE TABLE IF NOT EXISTS order_items (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      order_id uuid REFERENCES orders(id) ON DELETE CASCADE,
+      product_id text NOT NULL,
+      quantity integer NOT NULL,
+      price numeric NOT NULL,
+      product_name text,
+      price_at_purchase numeric
+    )
+  `
+}
+
+export async function listOrders(page = 1, limit = 10): Promise<{ orders: Order[]; totalCount: number }> {
+  await createOrdersTables()
+  const offset = (page - 1) * limit
+  const orders = (await sql`
+    SELECT o.*, COALESCE(json_agg(oi.*) FILTER (WHERE oi.id IS NOT NULL), '[]') AS order_items
+    FROM orders o
+    LEFT JOIN order_items oi ON o.id = oi.order_id
+    GROUP BY o.id
+    ORDER BY o.created_at DESC
+    LIMIT ${limit} OFFSET ${offset}
+  `) as any as Order[]
+  const countRes = (await sql`SELECT COUNT(*)::int as count FROM orders`) as { count: number }[]
+  return { orders, totalCount: countRes[0]?.count || 0 }
+}
+
+export async function getOrderById(id: string): Promise<Order | null> {
+  await createOrdersTables()
+  const orders = (await sql`
+    SELECT o.*, COALESCE(json_agg(oi.*) FILTER (WHERE oi.id IS NOT NULL), '[]') AS order_items
+    FROM orders o
+    LEFT JOIN order_items oi ON o.id = oi.order_id
+    WHERE o.id = ${id}
+    GROUP BY o.id
+    LIMIT 1
+  `) as any as Order[]
+  return orders[0] || null
+}
+
+export async function createOrder(data: OrderInput): Promise<Order> {
+  await createOrdersTables()
+  const shippingJson = data.shipping_address ? JSON.stringify(data.shipping_address) : null
+  const result = (await sql`
+    INSERT INTO orders (user_id, total_amount, status, payment_status, notes, shipping_address, invoice_url, invoice_id)
+    VALUES (
+      ${data.user_id},
+      ${data.total_amount},
+      ${data.status},
+      ${data.payment_status},
+      ${data.notes},
+      ${shippingJson}::jsonb,
+      ${data.invoice_url},
+      ${data.invoice_id}
+    )
+    RETURNING *
+  `) as Order[]
+  const order = result[0]
+  if (data.order_items && data.order_items.length > 0) {
+    for (const item of data.order_items) {
+      await sql`
+        INSERT INTO order_items (order_id, product_id, quantity, price, product_name, price_at_purchase)
+        VALUES (${order.id}, ${item.product_id}, ${item.quantity}, ${item.price}, ${item.product_name}, ${item.price_at_purchase})
+      `
+    }
+  }
+  return (await getOrderById(order.id)) as Order
+}
+
+export async function updateOrder(id: string, data: Partial<Order>): Promise<Order | null> {
+  await createOrdersTables()
+  const shippingJson = data.shipping_address ? JSON.stringify(data.shipping_address) : undefined
+  const result = (await sql`
+    UPDATE orders SET
+      user_id = COALESCE(${data.user_id}, user_id),
+      total_amount = COALESCE(${data.total_amount}, total_amount),
+      status = COALESCE(${data.status}, status),
+      payment_status = COALESCE(${data.payment_status}, payment_status),
+      notes = COALESCE(${data.notes}, notes),
+      shipping_address = COALESCE(${shippingJson}::jsonb, shipping_address),
+      invoice_url = COALESCE(${data.invoice_url}, invoice_url),
+      invoice_id = COALESCE(${data.invoice_id}, invoice_id)
+    WHERE id = ${id}
+    RETURNING *
+  `) as Order[]
+  if (!result[0]) return null
+  return (await getOrderById(id))
+}
+
+export async function deleteOrder(id: string): Promise<boolean> {
+  await createOrdersTables()
+  const result = await sql`DELETE FROM orders WHERE id = ${id}`
+  return (result as any).rowCount > 0
+}

--- a/lib/services/orders.ts
+++ b/lib/services/orders.ts
@@ -1,0 +1,103 @@
+import { mockOrders, MockOrder } from '@/lib/mock/orders'
+import { mockPayments, mockShippings } from '@/lib/mockDb'
+import { Order } from '@/types/order'
+
+export async function listOrders(page = 1, limit = 10): Promise<{ orders: Order[]; totalCount: number }> {
+  const offset = (page - 1) * limit
+  const orders = mockOrders.slice(offset, offset + limit) as Order[]
+  return { orders, totalCount: mockOrders.length }
+}
+
+export async function getOrderById(id: string): Promise<Order | null> {
+  return (mockOrders.find(o => o.id === id) as Order) || null
+}
+
+export interface CartItem { id: string; quantity: number; base_price: number }
+
+export async function createOrder(
+  userId: string,
+  totalAmount: number,
+  cartItems: CartItem[],
+  shipping?: {
+    address: string
+    city: string
+    state: string
+    zip: string
+    country: string
+  }
+): Promise<Order> {
+  const newId = (mockOrders.length + 1).toString()
+  const createdAt = new Date().toISOString()
+  const shippingAddress = shipping
+    ? {
+        name: '',
+        address_line1: shipping.address,
+        city: shipping.city,
+        state: shipping.state,
+        zip_code: shipping.zip,
+        country: shipping.country,
+      }
+    : {
+        name: '',
+        address_line1: '',
+        city: '',
+        state: '',
+        zip_code: '',
+        country: '',
+      }
+  const order: Order = {
+    id: newId,
+    user_id: userId,
+    total_amount: totalAmount,
+    status: 'pending',
+    payment_status: 'unpaid',
+    created_at: createdAt,
+    shipping_address: shippingAddress,
+    order_items: cartItems.map((ci, idx) => ({
+      id: `${idx + 1}`,
+      order_id: newId,
+      product_id: ci.id,
+      quantity: ci.quantity,
+      price: ci.base_price,
+      price_at_purchase: ci.base_price,
+    })),
+  }
+  mockOrders.push(order as MockOrder)
+  const paymentId = `pay_${mockPayments.length + 1}`
+  mockPayments.push({
+    id: paymentId,
+    order_id: newId,
+    amount: totalAmount,
+    status: 'unpaid',
+    created_at: createdAt,
+    updated_at: createdAt,
+  })
+  mockShippings.push({
+    id: newId,
+    order_id: newId,
+    status: 'processing',
+    updated_at: createdAt,
+  })
+  return order
+}
+
+export async function updateOrder(id: string, data: Partial<Order>): Promise<Order | null> {
+  const idx = mockOrders.findIndex(o => o.id === id)
+  if (idx === -1) return null
+  const existing = mockOrders[idx]
+  mockOrders[idx] = { ...existing, ...data } as MockOrder
+  return mockOrders[idx] as Order
+}
+
+export async function deleteOrder(id: string): Promise<boolean> {
+  const orderIdx = mockOrders.findIndex(o => o.id === id)
+  if (orderIdx >= 0) {
+    mockOrders.splice(orderIdx, 1)
+    const paymentIdx = mockPayments.findIndex(p => p.order_id === id)
+    if (paymentIdx >= 0) mockPayments.splice(paymentIdx, 1)
+    const shipIdx = mockShippings.findIndex(s => s.order_id === id)
+    if (shipIdx >= 0) mockShippings.splice(shipIdx, 1)
+    return true
+  }
+  return false
+}

--- a/types/order.ts
+++ b/types/order.ts
@@ -1,0 +1,32 @@
+export interface OrderItem {
+  id: string
+  order_id: string
+  product_id: string
+  quantity: number
+  price: number
+  product_name?: string
+  price_at_purchase?: number
+}
+
+export interface Order {
+  id: string
+  user_id: string
+  total_amount: number
+  status: string
+  payment_status: 'paid' | 'unpaid' | 'refunded'
+  created_at: string
+  notes?: string
+  shipping_address?: {
+    name: string
+    address_line1: string
+    address_line2?: string
+    city: string
+    state: string
+    zip_code: string
+    country?: string
+    phone?: string
+  }
+  order_items?: OrderItem[]
+  invoice_url?: string
+  invoice_id?: string
+}

--- a/types/order.ts
+++ b/types/order.ts
@@ -5,7 +5,9 @@ export interface OrderItem {
   quantity: number
   price: number
   product_name?: string
-  price_at_purchase?: number
+  price_at_purchase: number
+  product_image_url?: string
+  product_slug?: string
 }
 
 export interface Order {


### PR DESCRIPTION
## Summary
- add Postgres-backed orders service with tables and CRUD
- provide mock orders service for environments without Postgres
- wire admin orders page and actions to new service

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68971ee739c0832593f43fb92f503a99