### PR TITLE
Handle invoice creation errors

### DIFF
--- a/actions/orders.ts
+++ b/actions/orders.ts
@@ -97,7 +97,11 @@ export async function createInvoiceForOrder(orderId: string) {
   if (order.invoice_url) {
     return { success: true, invoiceUrl: order.invoice_url }
   }
-  const invoice = await generateInvoice(orderId, order.total_amount)
+  const invoiceResult = await generateInvoice(orderId, order.total_amount)
+  if (!invoiceResult.success) {
+    return { success: false, error: invoiceResult.error }
+  }
+  const invoice = invoiceResult.invoice
   await service.updateOrder(orderId, { invoice_url: invoice.url, invoice_id: invoice.id })
   return { success: true, invoiceUrl: invoice.url }
 }

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -109,7 +109,7 @@ export default function AdminOrders() {
       setOrders(fetchedOrders)
       alert('สร้างใบแจ้งหนี้เรียบร้อย')
     } else {
-      alert(result.error)
+      alert(`ไม่สามารถสร้างใบแจ้งหนี้ได้: ${result.error}`)
     }
   }
 

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -9,49 +9,64 @@ export interface Invoice {
   created_at: string
 }
 
+export type InvoiceResult =
+  | { success: true; invoice: Invoice }
+  | { success: false; error: string }
+
 /**
  * Create an invoice using Stripe if credentials are available. When Stripe is
  * not configured a mock invoice object will be returned. This keeps tests and
  * local development from requiring external network calls.
  */
-export async function generateInvoice(orderId: string, amount: number): Promise<Invoice> {
+export async function generateInvoice(orderId: string, amount: number): Promise<InvoiceResult> {
   const createdAt = new Date().toISOString()
   const stripeKey = process.env.STRIPE_SECRET_KEY
   if (!stripeKey) {
     return {
-      id: `inv_${Date.now()}`,
-      order_id: orderId,
-      amount,
-      status: 'draft',
-      url: `https://example.com/invoices/${orderId}.pdf`,
-      created_at: createdAt,
+      success: true,
+      invoice: {
+        id: `inv_${Date.now()}`,
+        order_id: orderId,
+        amount,
+        status: 'draft',
+        url: `https://example.com/invoices/${orderId}.pdf`,
+        created_at: createdAt,
+      },
     }
   }
 
-  const stripe = new Stripe(stripeKey)
-  // For demonstration purposes a hard coded customer is used. Real
-  // implementations should associate a Stripe customer with the order's user.
-  const customer = await stripe.customers.create({
-    description: `Customer for order ${orderId}`,
-  })
-  await stripe.invoiceItems.create({
-    customer: customer.id,
-    amount: Math.round(amount * 100),
-    currency: 'thb',
-    description: `Order ${orderId}`,
-  })
-  const invoice = await stripe.invoices.create({
-    customer: customer.id,
-    auto_advance: true,
-    collection_method: 'send_invoice',
-  })
-  return {
-    id: invoice.id || '',
-    order_id: orderId,
-    amount,
-    status: (invoice.status as Invoice['status']) || 'draft',
-    url: invoice.hosted_invoice_url || '',
-    created_at: new Date((invoice.created || Date.now()) * 1000).toISOString(),
+  try {
+    const stripe = new Stripe(stripeKey)
+    // For demonstration purposes a hard coded customer is used. Real
+    // implementations should associate a Stripe customer with the order's user.
+    const customer = await stripe.customers.create({
+      description: `Customer for order ${orderId}`,
+    })
+    await stripe.invoiceItems.create({
+      customer: customer.id,
+      amount: Math.round(amount * 100),
+      currency: 'thb',
+      description: `Order ${orderId}`,
+    })
+    const invoice = await stripe.invoices.create({
+      customer: customer.id,
+      auto_advance: true,
+      collection_method: 'send_invoice',
+    })
+    return {
+      success: true,
+      invoice: {
+        id: invoice.id || '',
+        order_id: orderId,
+        amount,
+        status: (invoice.status as Invoice['status']) || 'draft',
+        url: invoice.hosted_invoice_url || '',
+        created_at: new Date((invoice.created || Date.now()) * 1000).toISOString(),
+      },
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { success: false, error: message }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add InvoiceResult type and wrap Stripe invoice creation in try/catch
- Propagate invoice generation errors back through createInvoiceForOrder
- Display alert when admin invoice generation fails

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6897277054e48325b7f99f2a3ad14a53