### PR TITLE
feat: save RFQ submissions as leads

### DIFF
--- a/actions/leads.ts
+++ b/actions/leads.ts
@@ -41,6 +41,35 @@ export async function addLead(formData: FormData): Promise<ActionResult> {
   }
 }
 
+export async function addLeadFromJson(data: {
+  name: string
+  company?: string
+  phone?: string
+  email: string
+  message?: string
+  productInterest?: string[]
+}): Promise<ActionResult> {
+  try {
+    const now = new Date().toISOString()
+    const newLead: Lead = {
+      id: (mockLeads.length + 1).toString(),
+      email: data.email,
+      customer_name: data.name,
+      phone: data.phone ?? '',
+      product_interest: data.productInterest?.join(', ') ?? '',
+      status: 'รอติดต่อ',
+      created_at: now,
+      updated_at: now,
+      notes: data.message ? [data.message] : [],
+      company: data.company,
+    }
+    mockLeads.push(newLead)
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: 'Failed to add lead' }
+  }
+}
+
 export async function deleteLead(id: string): Promise<ActionResult> {
   const idx = mockLeads.findIndex(l => l.id === id)
   if (idx >= 0) {

--- a/app/api/rfq/route.ts
+++ b/app/api/rfq/route.ts
@@ -1,13 +1,32 @@
 import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { addLeadFromJson } from "@/actions/leads"
+
+const rfqSchema = z.object({
+  name: z.string().min(1),
+  company: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email(),
+  message: z.string().optional(),
+  utm: z.record(z.any()).optional(),
+  productInterest: z.array(z.string()).optional(),
+})
 
 export async function POST(req: NextRequest) {
   try {
     const data = await req.json()
-    console.log("RFQ submitted", data)
-    // TODO: save to DB or send email
+    const parsed = rfqSchema.parse(data)
+    console.log("RFQ submitted", parsed)
+    const result = await addLeadFromJson(parsed)
+    if (!result.success) {
+      return NextResponse.json(result, { status: 500 })
+    }
     return NextResponse.json({ success: true })
   } catch (error) {
     console.error("RFQ error", error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
     return NextResponse.json({ success: false }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- validate RFQ requests with zod
- store RFQ submissions in mock leads database

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897379b9d0c8325aab3bc439b52c5d6