### PR TITLE
feat: expand lead management actions

### DIFF
--- a/__tests__/leads.test.ts
+++ b/__tests__/leads.test.ts
@@ -1,0 +1,48 @@
+import {
+  addLeadFromJson,
+  fetchLeadCount,
+  getLeadById,
+  updateLead,
+  updateLeadStatus,
+  addNoteToLead,
+  searchLeads,
+  deleteLead,
+} from '@/actions/leads'
+
+describe('leads actions', () => {
+  test('addLeadFromJson increases count', async () => {
+    const initial = await fetchLeadCount()
+    const result = await addLeadFromJson({ name: 'Tester', email: 'tester@example.com' })
+    expect(result.success).toBe(true)
+    const count = await fetchLeadCount()
+    expect(count).toBe(initial + 1)
+  })
+
+  test('get, update, and note lead', async () => {
+    const { success } = await addLeadFromJson({ name: 'Updater', email: 'updater@example.com' })
+    expect(success).toBe(true)
+    const count = await fetchLeadCount()
+    const id = count.toString()
+    let lead = await getLeadById(id)
+    expect(lead?.email).toBe('updater@example.com')
+
+    await updateLead(id, { phone: '123' })
+    await updateLeadStatus(id, 'กำลังเจรจา')
+    await addNoteToLead(id, 'call soon')
+
+    lead = await getLeadById(id)
+    expect(lead?.phone).toBe('123')
+    expect(lead?.status).toBe('กำลังเจรจา')
+    expect(lead?.notes?.[0]).toBe('call soon')
+  })
+
+  test('search and delete lead', async () => {
+    const { success } = await addLeadFromJson({ name: 'Searchable', email: 'searchable@example.com' })
+    expect(success).toBe(true)
+    const leads = await searchLeads({ name: 'Searchable' })
+    expect(leads.length).toBeGreaterThan(0)
+    const id = leads[0].id
+    const del = await deleteLead(id)
+    expect(del.success).toBe(true)
+  })
+})

--- a/__tests__/leads.test.ts
+++ b/__tests__/leads.test.ts
@@ -68,19 +68,20 @@ describe('leads actions', () => {
       body: JSON.stringify({ status: 'ติดตามผล', note: 'initial contact' }),
       headers: { 'Content-Type': 'application/json' },
     })
-    res = await patchLeadApi(patchReq, { params: { id: lead.id } })
+    res = await patchLeadApi(patchReq, { params: Promise.resolve({ id: lead.id }) })
     expect(res.status).toBe(200)
 
-    const singleRes = await getLeadApi(new NextRequest(`http://localhost/api/leads/${lead.id}`), {
-      params: { id: lead.id },
-    })
+    const singleRes = await getLeadApi(
+      new NextRequest(`http://localhost/api/leads/${lead.id}`),
+      { params: Promise.resolve({ id: lead.id }) },
+    )
     const singleData: any = await singleRes.json()
     expect(singleData.lead.status).toBe('ติดตามผล')
     expect(singleData.lead.notes[0]).toBe('initial contact')
 
     const delRes = await deleteLeadApi(
       new NextRequest(`http://localhost/api/leads/${lead.id}`, { method: 'DELETE' }),
-      { params: { id: lead.id } },
+      { params: Promise.resolve({ id: lead.id }) },
     )
     expect(delRes.status).toBe(200)
   })

--- a/__tests__/users.test.ts
+++ b/__tests__/users.test.ts
@@ -1,0 +1,65 @@
+import {
+  createUser,
+  fetchUserCount,
+  fetchUserById,
+  updateUser,
+  deleteUser as deleteUserAction,
+} from '@/actions/users'
+import { GET as listUsersApi, POST as createUserApi } from '@/app/api/users/route'
+import { GET as getUserApi, PATCH as patchUserApi, DELETE as deleteUserApi } from '@/app/api/users/[id]/route'
+import { NextRequest } from 'next/server'
+
+describe('users actions', () => {
+  test('createUser increases count', async () => {
+    const initial = await fetchUserCount()
+    const result = await createUser({ email: 'new@example.com', password: 'secret123', role: 'viewer' })
+    expect(result.success).toBe(true)
+    const after = await fetchUserCount()
+    expect(after.count).toBe(initial.count + 1)
+  })
+
+  test('update and delete user', async () => {
+    const { user } = await createUser({ email: 'upd@example.com', password: 'secret123', role: 'viewer' })
+    const upd = await updateUser(user!.id, { user_metadata: { role: 'admin' } })
+    expect(upd.success).toBe(true)
+    const fetched = await fetchUserById(user!.id)
+    expect(fetched.user?.user_metadata.role).toBe('admin')
+    const del = await deleteUserAction(user!.id)
+    expect(del.success).toBe(true)
+  })
+
+  test('API routes create, update, and delete user', async () => {
+    const postReq = new NextRequest('http://localhost/api/users', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'api@example.com', password: 'secret123', role: 'viewer' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    let res = await createUserApi(postReq)
+    expect(res.status).toBe(200)
+
+    const listRes = await listUsersApi(new NextRequest('http://localhost/api/users'))
+    const listData: any = await listRes.json()
+    const user = listData.users.find((u: any) => u.email === 'api@example.com')
+    expect(user).toBeTruthy()
+
+    const patchReq = new NextRequest(`http://localhost/api/users/${user.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ role: 'admin' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    res = await patchUserApi(patchReq, { params: { id: user.id } })
+    expect(res.status).toBe(200)
+
+    const singleRes = await getUserApi(new NextRequest(`http://localhost/api/users/${user.id}`), {
+      params: { id: user.id },
+    })
+    const singleData: any = await singleRes.json()
+    expect(singleData.user.user_metadata.role).toBe('admin')
+
+    const delRes = await deleteUserApi(
+      new NextRequest(`http://localhost/api/users/${user.id}`, { method: 'DELETE' }),
+      { params: { id: user.id } },
+    )
+    expect(delRes.status).toBe(200)
+  })
+})

--- a/__tests__/users.test.ts
+++ b/__tests__/users.test.ts
@@ -47,18 +47,19 @@ describe('users actions', () => {
       body: JSON.stringify({ role: 'admin' }),
       headers: { 'Content-Type': 'application/json' },
     })
-    res = await patchUserApi(patchReq, { params: { id: user.id } })
+    res = await patchUserApi(patchReq, { params: Promise.resolve({ id: user.id }) })
     expect(res.status).toBe(200)
 
-    const singleRes = await getUserApi(new NextRequest(`http://localhost/api/users/${user.id}`), {
-      params: { id: user.id },
-    })
+    const singleRes = await getUserApi(
+      new NextRequest(`http://localhost/api/users/${user.id}`),
+      { params: Promise.resolve({ id: user.id }) },
+    )
     const singleData: any = await singleRes.json()
     expect(singleData.user.user_metadata.role).toBe('admin')
 
     const delRes = await deleteUserApi(
       new NextRequest(`http://localhost/api/users/${user.id}`, { method: 'DELETE' }),
-      { params: { id: user.id } },
+      { params: Promise.resolve({ id: user.id }) },
     )
     expect(delRes.status).toBe(200)
   })

--- a/actions/leads.ts
+++ b/actions/leads.ts
@@ -41,6 +41,35 @@ export async function addLead(formData: FormData): Promise<ActionResult> {
   }
 }
 
+export async function addLeadFromJson(data: {
+  name: string
+  company?: string
+  phone?: string
+  email: string
+  message?: string
+  productInterest?: string[]
+}): Promise<ActionResult> {
+  try {
+    const now = new Date().toISOString()
+    const newLead: Lead = {
+      id: (mockLeads.length + 1).toString(),
+      email: data.email,
+      customer_name: data.name,
+      phone: data.phone ?? '',
+      product_interest: data.productInterest?.join(', ') ?? '',
+      status: 'รอติดต่อ',
+      created_at: now,
+      updated_at: now,
+      notes: data.message ? [data.message] : [],
+      company: data.company,
+    }
+    mockLeads.push(newLead)
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: 'Failed to add lead' }
+  }
+}
+
 export async function deleteLead(id: string): Promise<ActionResult> {
   const idx = mockLeads.findIndex(l => l.id === id)
   if (idx >= 0) {
@@ -73,4 +102,41 @@ export async function addNoteToLead(id: string, note: string): Promise<ActionRes
   lead.notes.push(note)
   lead.updated_at = new Date().toISOString()
   return { success: true }
+}
+
+export async function getLeadById(id: string): Promise<Lead | null> {
+  const lead = mockLeads.find(l => l.id === id)
+  return lead ?? null
+}
+
+export async function updateLead(
+  id: string,
+  data: Partial<Pick<Lead, 'email' | 'customer_name' | 'phone' | 'product_interest' | 'company' | 'size' | 'quantity' | 'address'>>
+): Promise<ActionResult> {
+  const lead = mockLeads.find(l => l.id === id)
+  if (!lead) {
+    return { success: false, error: 'Lead not found' }
+  }
+  Object.assign(lead, data)
+  lead.updated_at = new Date().toISOString()
+  return { success: true }
+}
+
+export async function searchLeads(query: {
+  name?: string
+  email?: string
+  status?: string
+}): Promise<Lead[]> {
+  return mockLeads.filter(l => {
+    if (query.name && !l.customer_name.toLowerCase().includes(query.name.toLowerCase())) {
+      return false
+    }
+    if (query.email && l.email !== query.email) {
+      return false
+    }
+    if (query.status && l.status !== query.status) {
+      return false
+    }
+    return true
+  })
 }

--- a/actions/users.ts
+++ b/actions/users.ts
@@ -15,6 +15,11 @@ export async function fetchRecentUsers(limit: number): Promise<{ users: User[]; 
   return { users: mockUsers.slice(0, limit), error: null }
 }
 
+export async function fetchUserById(id: string): Promise<{ user: User | null; error: null }> {
+  const user = mockUsers.find(u => u.id === id) || null
+  return { user, error: null }
+}
+
 type ActionResult<T = {}> = { success: boolean; error?: string } & T
 
 export async function updateUserRole(): Promise<ActionResult<{ user: User | null }>> {

--- a/app/api/leads/[id]/route.ts
+++ b/app/api/leads/[id]/route.ts
@@ -21,28 +21,36 @@ const updateSchema = z.object({
   note: z.string().optional(),
 })
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
-  const lead = await getLeadById(params.id)
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const lead = await getLeadById(id)
   if (!lead) {
     return NextResponse.json({ success: false, error: 'Lead not found' }, { status: 404 })
   }
   return NextResponse.json({ success: true, lead })
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   try {
     const data = updateSchema.parse(await req.json())
+    const { id } = await params
     if (data.note) {
-      await addNoteToLead(params.id, data.note)
+      await addNoteToLead(id, data.note)
     }
     if (data.status) {
-      await updateLeadStatus(params.id, data.status)
+      await updateLeadStatus(id, data.status)
     }
     const fields: any = { ...data }
     delete fields.note
     delete fields.status
     if (Object.keys(fields).length > 0) {
-      await updateLead(params.id, fields)
+      await updateLead(id, fields)
     }
     return NextResponse.json({ success: true })
   } catch (error) {
@@ -54,8 +62,12 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   }
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
-  const result = await deleteLead(params.id)
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const result = await deleteLead(id)
   return NextResponse.json(result, { status: result.success ? 200 : 404 })
 }
 

--- a/app/api/leads/[id]/route.ts
+++ b/app/api/leads/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  getLeadById,
+  updateLead,
+  updateLeadStatus,
+  addNoteToLead,
+  deleteLead,
+} from '@/actions/leads'
+
+const updateSchema = z.object({
+  email: z.string().email().optional(),
+  customer_name: z.string().optional(),
+  phone: z.string().optional(),
+  product_interest: z.string().optional(),
+  company: z.string().optional(),
+  size: z.string().optional(),
+  quantity: z.string().optional(),
+  address: z.string().optional(),
+  status: z.string().optional(),
+  note: z.string().optional(),
+})
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const lead = await getLeadById(params.id)
+  if (!lead) {
+    return NextResponse.json({ success: false, error: 'Lead not found' }, { status: 404 })
+  }
+  return NextResponse.json({ success: true, lead })
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const data = updateSchema.parse(await req.json())
+    if (data.note) {
+      await addNoteToLead(params.id, data.note)
+    }
+    if (data.status) {
+      await updateLeadStatus(params.id, data.status)
+    }
+    const fields: any = { ...data }
+    delete fields.note
+    delete fields.status
+    if (Object.keys(fields).length > 0) {
+      await updateLead(params.id, fields)
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
+    console.error('Lead update error', error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  const result = await deleteLead(params.id)
+  return NextResponse.json(result, { status: result.success ? 200 : 404 })
+}
+

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { fetchLeads, addLeadFromJson, searchLeads } from '@/actions/leads'
+
+const leadSchema = z.object({
+  name: z.string().min(1),
+  company: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email(),
+  message: z.string().optional(),
+  productInterest: z.array(z.string()).optional(),
+})
+
+export async function GET(req: NextRequest) {
+  const params = req.nextUrl.searchParams
+  const query = {
+    name: params.get('name') ?? undefined,
+    email: params.get('email') ?? undefined,
+    status: params.get('status') ?? undefined,
+  }
+  const leads = Object.values(query).some(v => v) ? await searchLeads(query) : await fetchLeads()
+  return NextResponse.json({ success: true, leads })
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = leadSchema.parse(await req.json())
+    const result = await addLeadFromJson(data)
+    if (!result.success) {
+      return NextResponse.json(result, { status: 500 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
+    console.error('Lead create error', error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}
+

--- a/app/api/rfq/route.ts
+++ b/app/api/rfq/route.ts
@@ -1,13 +1,32 @@
 import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { addLeadFromJson } from "@/actions/leads"
+
+const rfqSchema = z.object({
+  name: z.string().min(1),
+  company: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email(),
+  message: z.string().optional(),
+  utm: z.record(z.any()).optional(),
+  productInterest: z.array(z.string()).optional(),
+})
 
 export async function POST(req: NextRequest) {
   try {
     const data = await req.json()
-    console.log("RFQ submitted", data)
-    // TODO: save to DB or send email
+    const parsed = rfqSchema.parse(data)
+    console.log("RFQ submitted", parsed)
+    const result = await addLeadFromJson(parsed)
+    if (!result.success) {
+      return NextResponse.json(result, { status: 500 })
+    }
     return NextResponse.json({ success: true })
   } catch (error) {
     console.error("RFQ error", error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
     return NextResponse.json({ success: false }, { status: 500 })
   }
 }

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { fetchUserById, updateUser, deleteUser } from '@/actions/users'
+
+const updateSchema = z.object({
+  email: z.string().email().optional(),
+  password: z.string().min(6).optional(),
+  role: z.string().optional(),
+})
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const { user } = await fetchUserById(params.id)
+  if (!user) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json({ user })
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const json = await req.json()
+    const parsed = updateSchema.parse(json)
+    const result = await updateUser(params.id, {
+      email: parsed.email,
+      password: parsed.password,
+      user_metadata: parsed.role ? { role: parsed.role } : undefined,
+    })
+    return NextResponse.json(result, { status: result.success ? 200 : 400 })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
+    console.error('User update error', error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const result = await deleteUser(params.id)
+  return NextResponse.json(result, { status: result.success ? 200 : 404 })
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -8,19 +8,27 @@ const updateSchema = z.object({
   role: z.string().optional(),
 })
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const { user } = await fetchUserById(params.id)
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const { user } = await fetchUserById(id)
   if (!user) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
   return NextResponse.json({ user })
 }
 
-export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   try {
     const json = await req.json()
     const parsed = updateSchema.parse(json)
-    const result = await updateUser(params.id, {
+    const { id } = await params
+    const result = await updateUser(id, {
       email: parsed.email,
       password: parsed.password,
       user_metadata: parsed.role ? { role: parsed.role } : undefined,
@@ -35,7 +43,11 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   }
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
-  const result = await deleteUser(params.id)
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const result = await deleteUser(id)
   return NextResponse.json(result, { status: result.success ? 200 : 404 })
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { fetchUsers, createUser } from '@/actions/users'
+
+const userSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+  role: z.string(),
+})
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const page = parseInt(searchParams.get('page') || '1', 10)
+  const limit = parseInt(searchParams.get('limit') || '10', 10)
+  const data = await fetchUsers(page, limit)
+  return NextResponse.json(data)
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const json = await req.json()
+    const parsed = userSchema.parse(json)
+    const result = await createUser(parsed)
+    return NextResponse.json(result, { status: result.success ? 200 : 400 })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ success: false, error: error.issues }, { status: 400 })
+    }
+    console.error('User creation error', error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add utilities to get, update, and search leads in the mock database
- cover lead creation, updates, notes, and deletion with tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6897379b9d0c8325aab3bc439b52c5d6