### PR TITLE
fix: handle missing supabase env

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,13 @@ import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next({ request: { headers: req.headers } })
 
+  const hasSupabaseCreds =
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!hasSupabaseCreds) {
+    return res
+  }
+
   const supabase = createMiddlewareClient({ req, res })
 
   const {


### PR DESCRIPTION
## Summary
- avoid crashing admin middleware when Supabase environment variables are absent

## Testing
- `npm test`
- `curl -I http://localhost:3001/admin`

------
https://chatgpt.com/codex/tasks/task_e_68975b3973bc8325acd5b754981e460c