### PR TITLE
feat: add global error boundary

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { StickyCTA } from "@/components/StickyCTA"
 import { TrackingConsent } from "@/components/TrackingConsent"
 import { products } from "@/lib/mockData"
+import { ErrorBoundary } from "@/components/ErrorBoundary"
 
 const inter = Inter({ subsets: ["latin"] })
 const sarabun = Sarabun({
@@ -103,7 +104,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </noscript>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           <Navbar />
-          <main className="min-h-screen">{children}</main>
+          <ErrorBoundary>
+            <main className="min-h-screen">{children}</main>
+          </ErrorBoundary>
           <Footer />
           <LiveChatWidget />
           <StickyCTA />

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import React from "react"
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // Log the error to the console or a monitoring service
+    console.error("ErrorBoundary caught an error", error, errorInfo)
+    // Example: send error to monitoring service
+    // monitoringService.log(error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center">
+          <h2 className="text-lg font-semibold">Something went wrong.</h2>
+          <p className="text-sm">Please try again later.</p>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary
+


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component that logs errors and shows a user-friendly fallback
- wrap layout `<main>` content with `ErrorBoundary` for app-wide safety

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68976d8e7c1883258a22ac9c343c614e